### PR TITLE
feat: configurable auth/codegen/search variants, new modules, and kit sync tooling

### DIFF
--- a/.claude/agents/git-end.md
+++ b/.claude/agents/git-end.md
@@ -20,7 +20,8 @@ Gdy user poda help — wypisz i zakończ (bez push/PR):
 ```markdown
 # /git-end — pomoc
 
-Push bieżącego feature brancha + `gh pr create` z `Closes #N`.
+Push bieżącego feature brancha + `gh pr create` z `Closes #N`. Po pushu wraca na branch
+sprzed `/git-start` (jeśli zapisany), jeśli nie — zostaje na feature branchu.
 
 ## Kiedy
 Po `/git-start`, implementacji, **`/git-commit`** (jeśli były lokalne zmiany) i **Twoim** `/review-*` (napraw findings).
@@ -93,14 +94,32 @@ EOF
 
 Bez `#N`: bez `Closes`. Istniejący PR: `gh pr view --json url -q .url`.
 
-### 4. Raport
+### 4. Powrót na branch sprzed `/git-start`
+
+Po udanym push+PR, **nie zostawaj** na feature branchu — wróć tam skąd user startował:
+
+```bash
+CUR_BRANCH=$(git branch --show-current)
+PREV=$(git config "branch.${CUR_BRANCH}.startedFrom" 2>/dev/null || true)
+if [[ -n "$PREV" ]] && git show-ref --verify --quiet "refs/heads/$PREV"; then
+  git checkout "$PREV"
+fi
+```
+
+Bezpieczne bo **po pushu** — praca feature brancha jest już na remote, nic nie ginie.
+Brak configu (branch stworzony ręcznie, nie przez `/git-start`) albo `PREV` już nie istnieje
+lokalnie → **zostań** na feature branchu, nie zgaduj docelowego (nie myl z `--base` PR-a —
+to inna rzecz, target mergu, nie branch do którego user wraca w IDE).
+
+### 5. Raport
 
 ```markdown
 ## /git-end OK
-- Branch: …
+- Branch: … (branch feature, z którego poszedł push/PR)
 - PR: <url>
-- Base: …
+- Base: … (target PR-a — merge base, nie branch powrotu)
 - Closes: #N
+- IDE teraz na: … (branch powrotu jeśli był zapisany, inaczej nadal branch feature)
 - Dalej: Autopilot → merge gdy green
 ```
 

--- a/.claude/agents/git-start.md
+++ b/.claude/agents/git-start.md
@@ -102,9 +102,13 @@ Kebab-case ASCII, 3–6 słów.
 git fetch --all --prune 2>/dev/null || true
 git status -sb
 gh repo view --json nameWithOwner,defaultBranchRef -q .
+PREV_BRANCH=$(git branch --show-current)
 ```
 
-Baza: `dev` jeśli istnieje, inaczej default branch.
+Baza: `dev` jeśli istnieje, inaczej default branch. Zapamiętaj `PREV_BRANCH` — to branch na
+którym stał user przed `/git-start` (najczęściej `main`/`master`/`dev`, czasem inny feature
+branch w toku). `/git-end` ma na niego wrócić po push+PR — zapisz go od razu w konfigu nowego
+brancha (krok 2–3), nie tylko w raporcie.
 
 ### 1. Issue
 
@@ -127,6 +131,16 @@ Albo (gdy CLI wspiera): `gh issue create … --json number,url -q .number`.
 Czysty tree + issue: `gh issue develop N --name "…" --base <baza> --checkout`.  
 Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 
+Zaraz po utworzeniu brancha (**każda** ścieżka powyżej), zapisz `PREV_BRANCH` do configu
+lokalnego dla tego brancha — to jedyny sposób żeby `/git-end` wiedział dokąd wrócić:
+
+```bash
+git config branch."<typ>/<N>-<slug>".startedFrom "$PREV_BRANCH"
+```
+
+Pomiń tylko gdy `PREV_BRANCH` jest puste (detached HEAD) — wtedy `/git-end` zostanie na
+feature branchu, bez próby powrotu.
+
 ### 4. Raport
 
 ```markdown
@@ -135,6 +149,7 @@ Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 - Issue: #N — title — url
 - Branch: …
 - Base: … (wanted / actual)
+- Powrót po `/git-end`: `$PREV_BRANCH` (zapisane w `branch.<nazwa>.startedFrom`)
 - Następne: **`/git-commit`** → review → **`/git-end`** (Ty) → [Autopilot]
 ```
 

--- a/.claude/agents/review-bugbot.md
+++ b/.claude/agents/review-bugbot.md
@@ -28,8 +28,11 @@ Brak findingów → jedna linia: "Brak uwag wg BUGBOT.md."
 
 W kolejności:
 
-1. `.cursor/BUGBOT.md` (najczęstsze — kopiowane przez bootstrap kita).
-2. `BUGBOT.md` w root repo.
+1. `BUGBOT.md` w root repo (kopiowany przez bootstrap kita **niezależnie od `--clients`** —
+   to ten plik dla wszystkich klientów, nie tylko Cursor).
+2. `.cursor/BUGBOT.md` (kopia dla natywnej usługi Cursor BugBot — istnieje tylko gdy
+   projekt bootstrapowano z `--clients cursor`/`all`; jeśli oba pliki istnieją, oba mają
+   tę samą treść — użyj root, nie czytaj dwa razy).
 3. Brak pliku → powiedz to wprost i zastosuj tylko reguły ogólne z `AGENTS.md` (sekrety, minimalny diff, brak testów).
 
 ### 2. Diff

--- a/.claude/commands/git-end.md
+++ b/.claude/commands/git-end.md
@@ -22,7 +22,8 @@ Gdy user poda help — wypisz i zakończ (bez push/PR):
 ```markdown
 # /git-end — pomoc
 
-Push bieżącego feature brancha + `gh pr create` z `Closes #N`.
+Push bieżącego feature brancha + `gh pr create` z `Closes #N`. Po pushu wraca na branch
+sprzed `/git-start` (jeśli zapisany), jeśli nie — zostaje na feature branchu.
 
 ## Kiedy
 Po `/git-start`, implementacji, **`/git-commit`** (jeśli były lokalne zmiany) i **Twoim** `/review-*` (napraw findings).
@@ -95,14 +96,32 @@ EOF
 
 Bez `#N`: bez `Closes`. Istniejący PR: `gh pr view --json url -q .url`.
 
-### 4. Raport
+### 4. Powrót na branch sprzed `/git-start`
+
+Po udanym push+PR, **nie zostawaj** na feature branchu — wróć tam skąd user startował:
+
+```bash
+CUR_BRANCH=$(git branch --show-current)
+PREV=$(git config "branch.${CUR_BRANCH}.startedFrom" 2>/dev/null || true)
+if [[ -n "$PREV" ]] && git show-ref --verify --quiet "refs/heads/$PREV"; then
+  git checkout "$PREV"
+fi
+```
+
+Bezpieczne bo **po pushu** — praca feature brancha jest już na remote, nic nie ginie.
+Brak configu (branch stworzony ręcznie, nie przez `/git-start`) albo `PREV` już nie istnieje
+lokalnie → **zostań** na feature branchu, nie zgaduj docelowego (nie myl z `--base` PR-a —
+to inna rzecz, target mergu, nie branch do którego user wraca w IDE).
+
+### 5. Raport
 
 ```markdown
 ## /git-end OK
-- Branch: …
+- Branch: … (branch feature, z którego poszedł push/PR)
 - PR: <url>
-- Base: …
+- Base: … (target PR-a — merge base, nie branch powrotu)
 - Closes: #N
+- IDE teraz na: … (branch powrotu jeśli był zapisany, inaczej nadal branch feature)
 - Dalej: Autopilot → merge gdy green
 ```
 

--- a/.claude/commands/git-start.md
+++ b/.claude/commands/git-start.md
@@ -104,9 +104,13 @@ Kebab-case ASCII, 3–6 słów.
 git fetch --all --prune 2>/dev/null || true
 git status -sb
 gh repo view --json nameWithOwner,defaultBranchRef -q .
+PREV_BRANCH=$(git branch --show-current)
 ```
 
-Baza: `dev` jeśli istnieje, inaczej default branch.
+Baza: `dev` jeśli istnieje, inaczej default branch. Zapamiętaj `PREV_BRANCH` — to branch na
+którym stał user przed `/git-start` (najczęściej `main`/`master`/`dev`, czasem inny feature
+branch w toku). `/git-end` ma na niego wrócić po push+PR — zapisz go od razu w konfigu nowego
+brancha (krok 2–3), nie tylko w raporcie.
 
 ### 1. Issue
 
@@ -129,6 +133,16 @@ Albo (gdy CLI wspiera): `gh issue create … --json number,url -q .number`.
 Czysty tree + issue: `gh issue develop N --name "…" --base <baza> --checkout`.  
 Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 
+Zaraz po utworzeniu brancha (**każda** ścieżka powyżej), zapisz `PREV_BRANCH` do configu
+lokalnego dla tego brancha — to jedyny sposób żeby `/git-end` wiedział dokąd wrócić:
+
+```bash
+git config branch."<typ>/<N>-<slug>".startedFrom "$PREV_BRANCH"
+```
+
+Pomiń tylko gdy `PREV_BRANCH` jest puste (detached HEAD) — wtedy `/git-end` zostanie na
+feature branchu, bez próby powrotu.
+
 ### 4. Raport
 
 ```markdown
@@ -137,6 +151,7 @@ Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 - Issue: #N — title — url
 - Branch: …
 - Base: … (wanted / actual)
+- Powrót po `/git-end`: `$PREV_BRANCH` (zapisane w `branch.<nazwa>.startedFrom`)
 - Następne: **`/git-commit`** → review → **`/git-end`** (Ty) → [Autopilot]
 ```
 

--- a/.claude/commands/review-bugbot.md
+++ b/.claude/commands/review-bugbot.md
@@ -29,8 +29,11 @@ Brak findingów → jedna linia: "Brak uwag wg BUGBOT.md."
 
 W kolejności:
 
-1. `.cursor/BUGBOT.md` (najczęstsze — kopiowane przez bootstrap kita).
-2. `BUGBOT.md` w root repo.
+1. `BUGBOT.md` w root repo (kopiowany przez bootstrap kita **niezależnie od `--clients`** —
+   to ten plik dla wszystkich klientów, nie tylko Cursor).
+2. `.cursor/BUGBOT.md` (kopia dla natywnej usługi Cursor BugBot — istnieje tylko gdy
+   projekt bootstrapowano z `--clients cursor`/`all`; jeśli oba pliki istnieją, oba mają
+   tę samą treść — użyj root, nie czytaj dwa razy).
 3. Brak pliku → powiedz to wprost i zastosuj tylko reguły ogólne z `AGENTS.md` (sekrety, minimalny diff, brak testów).
 
 ### 2. Diff

--- a/.cursor/agents/git-end.md
+++ b/.cursor/agents/git-end.md
@@ -20,7 +20,8 @@ Gdy user poda help — wypisz i zakończ (bez push/PR):
 ```markdown
 # /git-end — pomoc
 
-Push bieżącego feature brancha + `gh pr create` z `Closes #N`.
+Push bieżącego feature brancha + `gh pr create` z `Closes #N`. Po pushu wraca na branch
+sprzed `/git-start` (jeśli zapisany), jeśli nie — zostaje na feature branchu.
 
 ## Kiedy
 Po `/git-start`, implementacji, **`/git-commit`** (jeśli były lokalne zmiany) i **Twoim** `/review-*` (napraw findings).
@@ -93,14 +94,32 @@ EOF
 
 Bez `#N`: bez `Closes`. Istniejący PR: `gh pr view --json url -q .url`.
 
-### 4. Raport
+### 4. Powrót na branch sprzed `/git-start`
+
+Po udanym push+PR, **nie zostawaj** na feature branchu — wróć tam skąd user startował:
+
+```bash
+CUR_BRANCH=$(git branch --show-current)
+PREV=$(git config "branch.${CUR_BRANCH}.startedFrom" 2>/dev/null || true)
+if [[ -n "$PREV" ]] && git show-ref --verify --quiet "refs/heads/$PREV"; then
+  git checkout "$PREV"
+fi
+```
+
+Bezpieczne bo **po pushu** — praca feature brancha jest już na remote, nic nie ginie.
+Brak configu (branch stworzony ręcznie, nie przez `/git-start`) albo `PREV` już nie istnieje
+lokalnie → **zostań** na feature branchu, nie zgaduj docelowego (nie myl z `--base` PR-a —
+to inna rzecz, target mergu, nie branch do którego user wraca w IDE).
+
+### 5. Raport
 
 ```markdown
 ## /git-end OK
-- Branch: …
+- Branch: … (branch feature, z którego poszedł push/PR)
 - PR: <url>
-- Base: …
+- Base: … (target PR-a — merge base, nie branch powrotu)
 - Closes: #N
+- IDE teraz na: … (branch powrotu jeśli był zapisany, inaczej nadal branch feature)
 - Dalej: Autopilot → merge gdy green
 ```
 

--- a/.cursor/agents/git-start.md
+++ b/.cursor/agents/git-start.md
@@ -102,9 +102,13 @@ Kebab-case ASCII, 3–6 słów.
 git fetch --all --prune 2>/dev/null || true
 git status -sb
 gh repo view --json nameWithOwner,defaultBranchRef -q .
+PREV_BRANCH=$(git branch --show-current)
 ```
 
-Baza: `dev` jeśli istnieje, inaczej default branch.
+Baza: `dev` jeśli istnieje, inaczej default branch. Zapamiętaj `PREV_BRANCH` — to branch na
+którym stał user przed `/git-start` (najczęściej `main`/`master`/`dev`, czasem inny feature
+branch w toku). `/git-end` ma na niego wrócić po push+PR — zapisz go od razu w konfigu nowego
+brancha (krok 2–3), nie tylko w raporcie.
 
 ### 1. Issue
 
@@ -127,6 +131,16 @@ Albo (gdy CLI wspiera): `gh issue create … --json number,url -q .number`.
 Czysty tree + issue: `gh issue develop N --name "…" --base <baza> --checkout`.  
 Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 
+Zaraz po utworzeniu brancha (**każda** ścieżka powyżej), zapisz `PREV_BRANCH` do configu
+lokalnego dla tego brancha — to jedyny sposób żeby `/git-end` wiedział dokąd wrócić:
+
+```bash
+git config branch."<typ>/<N>-<slug>".startedFrom "$PREV_BRANCH"
+```
+
+Pomiń tylko gdy `PREV_BRANCH` jest puste (detached HEAD) — wtedy `/git-end` zostanie na
+feature branchu, bez próby powrotu.
+
 ### 4. Raport
 
 ```markdown
@@ -135,6 +149,7 @@ Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 - Issue: #N — title — url
 - Branch: …
 - Base: … (wanted / actual)
+- Powrót po `/git-end`: `$PREV_BRANCH` (zapisane w `branch.<nazwa>.startedFrom`)
 - Następne: **`/git-commit`** → review → **`/git-end`** (Ty) → [Autopilot]
 ```
 

--- a/.cursor/agents/review-bugbot.md
+++ b/.cursor/agents/review-bugbot.md
@@ -28,8 +28,11 @@ Brak findingów → jedna linia: "Brak uwag wg BUGBOT.md."
 
 W kolejności:
 
-1. `.cursor/BUGBOT.md` (najczęstsze — kopiowane przez bootstrap kita).
-2. `BUGBOT.md` w root repo.
+1. `BUGBOT.md` w root repo (kopiowany przez bootstrap kita **niezależnie od `--clients`** —
+   to ten plik dla wszystkich klientów, nie tylko Cursor).
+2. `.cursor/BUGBOT.md` (kopia dla natywnej usługi Cursor BugBot — istnieje tylko gdy
+   projekt bootstrapowano z `--clients cursor`/`all`; jeśli oba pliki istnieją, oba mają
+   tę samą treść — użyj root, nie czytaj dwa razy).
 3. Brak pliku → powiedz to wprost i zastosuj tylko reguły ogólne z `AGENTS.md` (sekrety, minimalny diff, brak testów).
 
 ### 2. Diff

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,15 +1,20 @@
 {
-  "mcpServers": {
-    "project-guides": {
-      "command": "uvx",
-      "args": [
-        "--from", "M:/projects/ai-instruction-kit-mcp",
-        "guides-mcp",
-        "--preset", "_base",
-        "--language", "pl",
-        "--clients", "cursor,claude",
-        "--workspace", "${CLAUDE_PROJECT_DIR:-.}"
-      ]
+    "mcpServers": {
+        "project-guides": {
+            "command": "uvx",
+            "args": [
+                "--from",
+                "M:/projects/ai-instruction-kit-mcp",
+                "guides-mcp",
+                "--preset",
+                "_base",
+                "--language",
+                "pl",
+                "--clients",
+                "cursor,claude",
+                "--workspace",
+                "${CLAUDE_PROJECT_DIR:-.}"
+            ]
+        }
     }
-  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Auth, ACL, billing, migracje, concurrency, brak dowodu w repo → **zapytaj uży
 
 ## Codegen (Orval)
 
-W overlay (`.ai/project.md` / extras) ustaw `codegen: orval` \| `manual` \| `none`.  
+W overlay (`.ai/project.md` / extras) ustaw `codegen: orval` (default) \| `none` \| `graphql`.  
 Docelowo też flaga MCP `--codegen` (design — jeszcze nie w CLI). Review FE/BE honorują tę wartość.  
 
 ## Język

--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -1,0 +1,66 @@
+# Bugbot — reguły projektu (monorepo Django + Expo)
+
+Dostosuj ścieżki i taski do `.ai/project.md`. Bugbot ładuje ten plik przy review PR.
+
+## Ogólne
+
+- Odpowiedzi agentów po polsku; kod po angielsku; docstringi po polsku.
+- Nie commituj `.env`, kluczy API, haseł, tokenów CI.
+- Preferuj minimalny diff — flaguj drive-by refactory poza zakresem PR.
+
+## Backend (`backend/`)
+
+If the PR modifies files under `backend/` and there are no changes in `backend/**/test*.py`, `backend/**/tests/**`, or `backend/**/*_test.py`:
+
+- Add a blocking bug titled "Missing tests for backend changes"
+- Body: "Dodaj lub zaktualizuj testy pytest dla zmian w backendzie."
+
+If changed files include serializers, viewsets, urls, or models affecting API
+**and** the project uses Orval (`codegen: orval` in `.ai/project.md` / extras, or REST+FE without `codegen: manual|none`):
+
+- Add a blocking bug unless `frontend/src/api/generated/` or Orval output was regenerated.
+- Body: "Po zmianie kontraktu API uruchom `task ovral:generate` i commituj wygenerowany klient."
+
+If overlay says `codegen: manual` or `codegen: none`: do **not** require Orval regeneration.
+
+If any changed Python file lacks type hints on new public functions:
+
+- Add a non-blocking finding per `core:typing-python`.
+
+Flag `eval(`, `exec(`, raw SQL string concatenation with user input, and `permission_classes = []` on new viewsets without justification.
+
+## Frontend (`frontend/`)
+
+If the PR modifies `frontend/` without `task lints:frontend:typecheck` passing (assume CI will catch — flag risky patterns):
+
+- Flag imports from `react-native` in `.web.tsx` files.
+- Flag `any` on new public interfaces without `@ts-expect-error` justification.
+
+If Expo native modules or `app.json` plugins change without EAS note in PR description:
+
+- Add a non-blocking finding: "Zmiana native — wymaga EAS build, nie tylko OTA."
+
+## Auth, ACL, płatności
+
+If changed paths match `**/auth/**`, `**/permissions/**`, `**/acl/**`, `**/payments/**`, `**/stripe/**`:
+
+- Add a blocking bug if webhook handlers skip signature verification.
+- Recommend `/review-security` in PR description if not already run locally.
+
+## Sekrety i compliance
+
+If dependency files change (`package.json`, `bun.lock`, `pyproject.toml`, `uv.lock`, `requirements.txt`):
+
+- Flag new dependencies with copyleft licenses (GPL, AGPL) if project policy forbids them.
+
+If diff contains patterns like `sk_live_`, `pk_live_`, `AWS_SECRET`, `password = "`:
+
+- Add a blocking bug titled "Possible hardcoded secret."
+
+## Taskfile
+
+When suggesting fixes, prefer `task <namespace>:<nazwa>` from `.ai/project.md` over raw docker/bash commands.
+
+## Lokalny workflow
+
+Przed pushem developer powinien uruchomić `/review-bugbot` w Cursor. Hook `.cursor/hooks/gate-push.sh` przypomina o tym przy `git push`.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,31 @@ W **repo aplikacji** uruchom `scripts/bootstrap-project.sh` albo skopiuj z `temp
 
 W projekcie docelowym **nie** duplikuj `modules/` — wystarczy preset + opcjonalny overlay.
 
+## Update kita w projekcie
+
+Bootstrap to **jednorazowy stempel**, nie sync. Trzy różne zachowania:
+
+| Co | Przy ponownym `bootstrap-project.sh` |
+| --- | --- |
+| `.claude/agents/`, `.cursor/agents/`, `.claude/commands/`, `mcp.json`/`config.toml` | **Zawsze nadpisane** świeżą kopią z kita — traktuj jak wygenerowany kod, nie edytuj ręcznie |
+| `AGENTS.md`, `.ai/project.md` | Kopiowane **tylko jeśli brak** — bootstrap nigdy więcej ich nie tyka, update ręczny |
+| `modules/*.md` (treść instrukcji) | **W ogóle nie kopiowane** — MCP czyta je live z `--from` przy każdym `get_bundle`/`get_overlay`, więc zawsze aktualne bez re-bootstrapu |
+
+Skąd wiedzieć **kiedy** re-bootstrapować (bez ciągłego czytania plików kita — tanie, jedno porównanie commitów):
+
+```text
+MCP tool: check_kit_status
+```
+
+Bootstrap zapisuje `.ai/.kit-bootstrap.json` (commit kita w momencie bootstrapu). `check_kit_status`
+porównuje go z aktualnym `HEAD` kita (`git rev-parse` + `git diff --name-only` tylko na ścieżkach
+które bootstrap faktycznie kopiuje) i zwraca: aktualny / zmienił się (+ lista plików) / brak stampu
+(stary bootstrap sprzed tej funkcji) / brak lokalnej historii git (gdy `--from` to zdalny URL, nie
+lokalny klon). Zero kosztu tokenów na nawigację plików — jedno wywołanie tool, agent woła je kiedy
+chce sprawdzić stan (np. na początku sesji), nie w pętli.
+
+Gdy pokaże zmiany: `bootstrap-project.sh` ponownie z tymi samymi flagami co poprzednio.
+
 ## Slash commands — konwencja nazw
 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Albo `--profile`, albo `--preset` — nie oba naraz. Bootstrap bez `--preset` w 
 
 **Klienci AI:** MCP tool `get_clients` — tylko metadane instalacji; treść `get_bundle` jest identyczna dla każdego klienta.
 
-**Codegen (Orval) — dziś w overlay, nie w CLI:** w `.ai/project.md` / `templates/extras.md` ustaw `codegen: orval` \| `manual` \| `none`. Reviewery FE/BE honorują to (przy `orval` wymagają regeneracji klienta po zmianie API). Docelowo flaga MCP `--codegen` — zob. design overlays.
+**Codegen (Orval) — dziś w overlay, nie w CLI:** w `.ai/project.md` / `templates/extras.md` ustaw `codegen: orval` (default) \| `none` \| `graphql`. Reviewery FE/BE honorują to (przy `orval` wymagają regeneracji klienta po zmianie API; `graphql` → `arch:api-contract:graphql` zamiast REST). Docelowo flaga MCP `--codegen` — zob. design overlays.
 
 **Sklep:** `"--preset", "shop"`. Szczegóły produktu tylko w `.ai/project.md`.
 
@@ -241,16 +241,17 @@ Co robi: odpala `npx skills@latest add mattpocock/skills` w `TARGET` (wymaga `np
 
 ```text
 modules/
-  core/              repo-first, workflow, typing, code-review, language-*
-  architecture/      platforms, CI/CD, API, security, testing, i18n, …
+  core/              repo-first, workflow, typing, code-review, language-*, tooling-rtk
+  architecture/      platforms, CI/CD, API (REST/GraphQL), security, testing, i18n,
+                     taskfile, docker-structure, …
   stacks/
     django-drf/      (+ django/, fastapi/, flask/ layouts)
     expo-router/
     frontend/        warianty Expo/React (macierz web/mobile — design)
-  capabilities/      auth, files, payments, …
+  capabilities/      auth (+ allauth/jwt/custom warianty), files, payments, …
   domains/           shop
-  patterns/          capability-provider, providers-and-settings, gateway…
-  infra/             database, cache, queue, storage, tasks
+  patterns/          capability-provider, providers-and-settings, gateway, webhooks, …
+  infra/             database, cache, queue, storage, tasks, search
 profiles/
   _base.yaml         fundament stacku (default)
   shop.yaml          kategoria e-commerce
@@ -271,9 +272,23 @@ decisions:
   queue: redis            # → infra:queue:redis  (lub rabbitmq)
   storage: s3             # → infra:storage:s3
   tasks: celery           # → infra:tasks:celery
+  search: postgres        # → infra:search:postgres (lub meilisearch)
 ```
 
 Moduły infra trafiają automatycznie do bundle `infra` i `devops`.
+
+## Wariant auth (`decisions.auth`)
+
+```yaml
+decisions:
+  auth: custom      # default — brak enforced pakietu, opisz w .ai/project.md
+  # auth: allauth   # → capability:auth:allauth (django-allauth headless)
+  # auth: jwt       # → capability:auth:jwt (djangorestframework-simplejwt)
+```
+
+Inny mechanizm niż infra: nie tworzy osobnego bundle'a — dokleja się zaraz po
+`capability:auth` wszędzie tam, gdzie ten moduł już jest wypisany w bundle
+(`capabilities: [auth]` albo ręcznie w `bundles.backend`/`bundles.frontend`).
 
 ## Bundle'e MCP
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Nie mieszaj: nazwa produktu ≠ preset; porty ≠ tag.
 | `--from SOURCE`    | tak (uvx) | Źródło kita: `git+https://…` albo absolutna ścieżka lokalna                                                                                        | `.cursor/mcp.json` (i odpowiedniki innych klientów)      |
 | `--preset NAME`    | tak       | Kategoria z `profiles/NAME.yaml` (`_base`, `shop`, …) — bez aliasów produktowych (używaj `shop`)                                                   | mcp.json; lista: MCP `list_presets` / `profiles/`        |
 | `--language pl|en` | nie       | Język **prozy** (odpowiedzi, docstringi, body issue/PR, commity). **Tytuły** issue/PR/branch zawsze EN. Domyślnie: `language:` w profilu albo `pl` | mcp.json / bootstrap `--language`; env `GUIDES_LANGUAGE` |
+| `--codegen orval\|none\|graphql` | nie | Generator klienta API — patrz sekcja "Codegen" niżej. Domyślnie: `orval` | mcp.json / bootstrap `--codegen`; env `GUIDES_CODEGEN`; tool `get_codegen` |
 | `--clients LIST`   | nie       | Metadane IDE: `all` \| `cursor` \| `claude` \| `codex` \| `vscode` \| `kiro` \| `kilo` \| `antigravity` \| `opencode` (lista; alias `copilot`→`vscode`). **Nie** zmienia treści bundle | mcp.json / bootstrap `--clients` (default `all`); env `GUIDES_CLIENTS`; tool `get_clients` |
 | `--workspace PATH` | zalecane  | Root aplikacji — stąd auto `.ai/project.md`                                                                                                        | mcp.json; Cursor/VS: `${workspaceFolder}`                |
 | `--overlay PATH`   | nie       | Extra MD (można wielokrotnie)                                                                                                                      | mcp.json — rzadko; zwykle wystarczy workspace            |
@@ -141,7 +142,9 @@ Szkic (nie działa jeszcze):
   --from /absolutna/sciezka/do/ai-instruction-kit-mcp
 ```
 
-Zapisuje m.in. MCP per klient (`--preset`, `--language`, `--clients`, `--workspace`), agents z `templates/shared/agents`, skill Cursor `/compact`, hooki `gate-*` (Cursor). Wymaga **Python 3** (`python3` albo `python` z major==3).
+Zapisuje m.in. MCP per klient (`--preset`, `--language`, `--codegen`, `--clients`, `--workspace`), agents z `templates/shared/agents`, `BUGBOT.md` w root (wszyscy klienci) + `.cursor/BUGBOT.md` (natywny Cursor BugBot), skill Cursor `/compact`, hooki `gate-*` (Cursor), stamp `.ai/.kit-bootstrap.json` (patrz "Update kita w projekcie"). Wymaga **Python 3** (`python3` albo `python` z major==3).
+
+**Declarative sync klientów:** domyślnie bootstrap **usuwa** kitowe pliki klientów spoza `--clients` (np. przełączenie z `--clients all` na `--clients claude` sprząta `.cursor/`, `.codex/` itd. wygenerowane przy poprzednim bootstrapie). Flaga `--keep-unselected-clients` wyłącza to sprzątanie — zostają pliki wszystkich klientów kiedykolwiek bootstrapowanych.
 
 ## MCP w innych klientach (multi-client)
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -35,6 +35,11 @@ modules:
     title: Code review — lokalnie, GitHub, raporty
     tags: [core, devops]
 
+  core:tooling-rtk:
+    path: modules/core/tooling-rtk.md
+    title: Shell proxy — RTK (jeśli dostępny)
+    tags: [core]
+
   # ─── Architecture ───────────────────────────────────
   arch:monorepo-layout:
     path: modules/architecture/monorepo-layout.md
@@ -44,6 +49,16 @@ modules:
   arch:api-contract:
     path: modules/architecture/api-contract.md
     title: Kontrakt API (OpenAPI, Orval)
+    tags: [architecture]
+
+  arch:api-contract:none:
+    path: modules/architecture/api-contract-none.md
+    title: Kontrakt API (OpenAPI, generyczny klient — bez Orval)
+    tags: [architecture]
+
+  arch:api-contract:graphql:
+    path: modules/architecture/api-contract-graphql.md
+    title: Kontrakt API — GraphQL
     tags: [architecture]
 
   arch:fe-be-separation:
@@ -100,6 +115,16 @@ modules:
     path: modules/architecture/platforms.md
     title: Platformy — backend, web, mobile
     tags: [architecture]
+
+  arch:taskfile:
+    path: modules/architecture/taskfile.md
+    title: Taskfile — jedyny punkt wejścia komend
+    tags: [architecture, devops]
+
+  arch:docker-structure:
+    path: modules/architecture/docker-structure.md
+    title: Docker — struktura i podział env
+    tags: [architecture, devops]
 
   core:typing-typescript:
     path: modules/core/typing-typescript.md
@@ -211,8 +236,23 @@ modules:
   # ─── Capabilities ───────────────────────────────────
   capability:auth:
     path: modules/capabilities/auth.md
-    title: Auth (allauth, sesja)
+    title: Auth — wspólne (wybór wariantu przez decisions.auth)
     tags: [capability, auth]
+
+  capability:auth:allauth:
+    path: modules/capabilities/auth-allauth.md
+    title: Auth — django-allauth headless
+    tags: [capability, auth, allauth]
+
+  capability:auth:jwt:
+    path: modules/capabilities/auth-jwt.md
+    title: Auth — JWT (djangorestframework-simplejwt)
+    tags: [capability, auth, jwt]
+
+  capability:auth:custom:
+    path: modules/capabilities/auth-custom.md
+    title: Auth — custom (własny schemat, default)
+    tags: [capability, auth, custom]
 
   capability:files:
     path: modules/capabilities/files.md
@@ -261,6 +301,11 @@ modules:
     title: Auth między mikroserwisami
     tags: [infra, auth]
 
+  pattern:webhooks:
+    path: modules/patterns/webhooks.md
+    title: Webhooks — podpis, idempotency, retry
+    tags: [architecture, webhooks]
+
   # ─── Infra: database ──────────────────────────────────
   infra:database:postgres:
     path: modules/infra/database/postgres.md
@@ -289,6 +334,17 @@ modules:
     path: modules/infra/storage/s3.md
     title: S3-compatible storage (MinIO, AWS)
     tags: [infra, storage]
+
+  # ─── Infra: search ─────────────────────────────────────
+  infra:search:postgres:
+    path: modules/infra/search/postgres.md
+    title: Search — Postgres full-text (tsvector)
+    tags: [infra, search]
+
+  infra:search:meilisearch:
+    path: modules/infra/search/meilisearch.md
+    title: Search — Meilisearch
+    tags: [infra, search]
 
   # ─── Infra: tasks ─────────────────────────────────────
   infra:tasks:celery:

--- a/modules/architecture/api-contract-graphql.md
+++ b/modules/architecture/api-contract-graphql.md
@@ -1,0 +1,60 @@
+# Kontrakt API — GraphQL
+
+Wariant `codegen: graphql`. Wybieraj świadomie — nie domyślny, nie migruj istniejącego REST+Orval
+bez konkretnego powodu (patrz "Kiedy to ma sens" niżej).
+
+## Różnica vs REST (`arch:api-contract`)
+
+REST: kształt odpowiedzi ustala backend per endpoint (`/api/products/5/` zawsze zwraca te same
+pola). Potrzebujesz węższego JSONa (np. lista produktów na mobile) → nowy endpoint albo query
+param.
+
+GraphQL: klient sam deklaruje w zapytaniu jakich pól chce (`{ product(id: 5) { name price } }`),
+serwer zwraca dokładnie to. Jeden endpoint (`/graphql`) zamiast wielu REST endpointów.
+
+## Kiedy to ma sens
+
+- Wiele bardzo różnych klientów (web, mobile, partner API) potrzebujących różnych podzbiorów
+  tych samych danych — bez mnożenia REST endpointów/serializerów per widok.
+- Głęboko zagnieżdżone dane w jednym query (produkt + warianty + recenzje + rekomendacje)
+  zamiast kaskady kilku REST requestów.
+
+Gdy tego nie ma — REST+Orval (`arch:api-contract`) jest prostszy i tańszy operacyjnie. Nie
+wybieraj GraphQL "bo popularne" (Saleor go używa, ale to inna skala i inny zespół).
+
+## Backend
+
+- `strawberry-django` (typed, dataclass-first) albo `graphene-django` — wybierz jedno,
+  udokumentuj w `.ai/project.md`.
+- **Problem N+1**: każde zagnieżdżone pole może odpalić osobny query per wiersz. Obowiązkowo
+  DataLoader (batching) dla relacji — inaczej jedno query listy = setki zapytań do DB.
+- Autoryzacja per pole/typ, nie tylko per endpoint jak w DRF permissions — łatwo przeoczyć
+  pole zwracające dane innego usera w zagnieżdżonym query.
+
+## Frontend
+
+- Klient: Apollo Client albo urql (nie fetch + Orval — inny model cache'owania, cache po
+  polach/ID obiektu, nie po URL).
+- Codegen: `graphql-codegen` generuje typy z `.graphql` query + schema — inny pipeline niż
+  Orval z OpenAPI, osobna komenda w Taskfile (`task graphql:generate`, nazwa do ustalenia
+  w `.ai/project.md`).
+- Przy 401: interceptor na poziomie link/exchange (Apollo `errorLink` / urql `authExchange`),
+  nie standardowy HTTP interceptor jak w REST.
+
+## Sekwencja po zmianie API
+
+```text
+backend (typ/resolver/schema) → task graphql:generate → task lints:frontend:typecheck
+```
+
+## Testowanie bez frontendu
+
+GraphiQL / Apollo Sandbox zamiast Swagger UI — backend musi być testowalny samodzielnie przed
+powstaniem UI, tak samo jak w REST.
+
+## Powiązane moduły
+
+- `arch:api-contract` — REST+Orval, default; przeczytaj przed wyborem GraphQL
+- `arch:api-errors` — GraphQL zwraca błędy inaczej (`errors[]` w response, nie HTTP status) —
+  ujednolić z resztą API jeśli monorepo miesza oba podejścia
+- `capability:auth` — autoryzacja per pole, nie tylko per endpoint

--- a/modules/architecture/api-contract-none.md
+++ b/modules/architecture/api-contract-none.md
@@ -1,0 +1,41 @@
+# Kontrakt API — schema-first (bez Orval)
+
+## Zasada
+
+Backend definiuje kontrakt; frontend go konsumuje. Kolejność pracy:
+
+1. Zaprojektuj endpoint (serializer + viewset).
+2. Zaktualizuj schema OpenAPI (`drf-spectacular` → `schema.yaml`).
+3. Wygeneruj typowanego klienta TypeScript narzędziem innym niż Orval (konkretne
+   narzędzie i komenda — overlay projektu `.ai/project.md`), albo utrzymuj typy ręcznie.
+4. Użyj wygenerowanych/ręcznych typów w frontendzie.
+
+## Backend
+
+- `drf-spectacular` generuje OpenAPI z DRF.
+- Schema trzymana w repo: `backend/src/schema.yaml` (lub export w CI).
+- Wersjonowanie URL: `/api/v1/...` gdy potrzebne breaking changes.
+
+## Frontend
+
+- Klient i typy w `frontend/src/api/generated/` (jeśli generowane) — **nie edytuj ręcznie**
+  wygenerowanych plików; jeśli typy pisane ręcznie — trzymaj je blisko warstwy API klienta.
+- Hooki TanStack Query owijają funkcje API.
+- Przy 401: interceptor → refresh sesji → retry (szczegóły w `capability:auth`).
+
+## Sekwencja po zmianie API
+
+```text
+backend (serializer/view/schema) → regeneracja/aktualizacja klienta (komenda w overlay
+projektu .ai/project.md) → task lints:frontend:typecheck
+```
+
+## Testowanie bez frontendu
+
+Backend musi być testowalny samodzielnie: pytest, Postman, Swagger UI — zanim powstanie UI.
+
+## Powiązane moduły
+
+- `stack:django-drf:backend-standard` — DRF-first
+- `arch:api-errors` — format błędów FE/BE
+- `stack:expo-router:structure` — gdzie trzymać klienta API

--- a/modules/architecture/docker-structure.md
+++ b/modules/architecture/docker-structure.md
@@ -1,0 +1,44 @@
+# Docker — struktura i podział env
+
+## Struktura folderu
+
+```text
+docker/
+├── django/
+│   └── Dockerfile
+├── postgres/
+│   └── Dockerfile          # jeśli custom (extensions, init scripts)
+├── .envs/
+│   ├── .django.env.example
+│   ├── .postgres.env.example
+│   └── .redis.env.example
+docker-compose.dev.yml
+docker-compose.test.yml
+docker-compose.prod.yml
+.env.example                # zmienne wspólne / root-level
+```
+
+## Zasady
+
+1. **Jeden Dockerfile per serwis** w `docker/<serwis>/Dockerfile` — nie jeden monolityczny Dockerfile na cały monorepo.
+2. **`.envs/` per serwis**, nie jeden płaski `.env` na wszystko — każdy serwis czyta tylko swój plik.
+3. **Trzy pliki compose**, nie jeden z profilami udającymi środowiska:
+   - `docker-compose.dev.yml` — hot-reload, volumes montowane, debug ports.
+   - `docker-compose.test.yml` — izolowane dane, używane przez CI i `task test:*`.
+   - `docker-compose.prod.yml` — bez bind-mountów kodu, healthchecks, restart policy.
+4. **`.env.example` obok każdego prawdziwego pliku env** — placeholdery, zero realnych sekretów.
+5. Realne `.env` / `docker/.envs/*.env` (bez `.example`) — **nigdy nie trafiają do gita, nigdy nie trafiają na GitHub**.
+   `.gitignore` musi je łapać explicit (`docker/.envs/*.env`, nie tylko `*.env` — żeby `.env.example` nie wpadł przez pomyłkę w szerszy pattern).
+6. Komendy Docker wołane przez Taskfile (`docker:*`), nie bezpośrednio — patrz `arch:taskfile`.
+
+## Antywzorce
+
+- Jeden `docker-compose.yml` + `profiles:` symulujące dev/test/prod — utrudnia czytelność diffu env.
+- Sekrety prod w `.env.example` "tymczasowo, wykasuję potem".
+- Dockerfile builduje FE i BE w jednym stage bez multi-stage separacji.
+
+## Powiązane
+
+- `arch:taskfile` — `docker:*` taski jako jedyny interfejs
+- `arch:configuration` — commituj `.env.example`, nigdy `.env`
+- `arch:ci-cd` — `docker-compose.test.yml` używany w testach integracyjnych

--- a/modules/architecture/taskfile.md
+++ b/modules/architecture/taskfile.md
@@ -1,0 +1,46 @@
+# Taskfile — jedyny punkt wejścia komend
+
+## Zasada
+
+`Taskfile.yml` w rootcie monorepo to **jedyne** źródło prawdy komend dev/test/CI/deploy.
+Nie surowy `docker compose ...`, nie `cd backend && uv run ...` z pamięci —
+zarówno człowiek jak i agent uruchamiają `task <namespace>:<nazwa>`.
+
+`task --list` musi zwracać kompletną, czytelną listę — to jest kontrakt discoverability,
+nie opcjonalny dodatek.
+
+## Namespacing
+
+Grupuj po warstwie/domenie, nie płasko:
+
+```text
+backend:*     # backend:run, backend:shell, backend:migrate
+frontend:*    # frontend:run, frontend:build
+docker:*      # docker:up, docker:down, docker:logs
+db:*          # db:migrate, db:seed, db:reset
+lints:*       # lints:backend:ruff:check, lints:frontend:lint:check
+test:*        # test:backend, test:frontend
+ovral:*       # ovral:generate (jeśli codegen: orval)
+```
+
+Task złożony (np. pełny setup) woła inne taski, nie duplikuje kroków.
+
+## Wymagania
+
+1. Każdy task ma `desc:` — to jest treść którą pokazuje `task --list`.
+2. Taski Docker/DB nigdy nie hardkodują sekretów — czytają z `.env` / `docker/.envs/*`.
+3. CI woła te same taski co dev (`arch:ci-cd`: "Taskfile jest źródłem prawdy komend —
+   CI wywołuje taski, nie kopiuje składni ad hoc").
+4. Zmiana nazwy/zachowania taska = zmiana w jednym miejscu (Taskfile), nie w docs + CI + README osobno.
+
+## Antywzorce
+
+- Komenda działa tylko "bo ktoś ją zna z historii shella" — brak taska = brak komendy.
+- Różne nazwy tej samej operacji w Taskfile vs Docker vs docs (`arch:configuration`).
+- Task bez `desc:` — niewidoczny w `task --list`, więc nieodkrywalny.
+
+## Powiązane
+
+- `arch:ci-cd` — CI woła taski, nie ad-hoc komendy
+- `arch:docker-structure` — taski `docker:*` operują na strukturze `docker/`
+- Overlay projektu (`.ai/project.md`) — konkretne nazwy tasków tego repo

--- a/modules/capabilities/auth-allauth.md
+++ b/modules/capabilities/auth-allauth.md
@@ -1,0 +1,34 @@
+# Auth — django-allauth headless
+
+Wariant `decisions.auth: allauth`. Preferowany dla web + mobile (Expo) w kategorii shop / `_base`.
+
+```text
+core/integrations/allauth/    # adaptery, taski cleanup
+apps/accounts/                # Profile, adresy — DRF CRUD (nie logika auth)
+```
+
+| Aspekt | Implementacja |
+|--------|---------------|
+| API auth | allauth headless — `_allauth/{browser\|app}/v1/` |
+| Web | cookies + CSRF, `allauthClient = "browser"` |
+| Mobile | `X-Session-Token` + SecureStore, `allauthClient = "app"` |
+| MFA | TOTP, recovery codes, WebAuthn |
+| Social | Google / Facebook via `expo-auth-session` + Dev Client |
+| Profile CRUD | DRF pod ścieżkami customers/accounts (profile, addresses) |
+
+## Orval
+
+Osobny klient wygenerowany z `/_allauth/openapi.json` + osobny mutator auth —
+**nie mieszaj** ze schema głównego DRF API. Dwa klienty, dwa mutatory:
+
+```text
+src/api/generated/allauth/   # z /_allauth/openapi.json, mutator: cookies/X-Session-Token
+src/api/generated/api/       # z DRF schema, mutator: standardowy
+```
+
+`task ovral:generate` regeneruje oba (dwa wejścia w `orval.config.ts`).
+
+## Powiązane
+
+- `capability:auth` — część wspólna (frontend, testy)
+- `arch:api-contract` — Orval, ogólne zasady kontraktu

--- a/modules/capabilities/auth-custom.md
+++ b/modules/capabilities/auth-custom.md
@@ -1,0 +1,23 @@
+# Auth — custom
+
+Wariant `decisions.auth: custom` (**default**). Kit nie narzuca pakietu/wzorca —
+projekt ma własny mechanizm albo jeszcze go nie wybrał.
+
+## Co zrobić
+
+1. Opisz realny kontrakt auth w `.ai/project.md`: endpointy, format tokena/sesji,
+   gdzie żyje weryfikacja, MFA/social jeśli jest.
+2. Jeśli docelowo to ma być allauth albo JWT — przełącz `decisions.auth` na `allauth` / `jwt`
+   zamiast utrzymywać opis ręcznie w overlay.
+3. Orval: standardowy, jeden klient z DRF schema — dopisz w overlay tylko co odbiega
+   (np. header auth inny niż `Authorization: Bearer`).
+
+## Dlaczego default custom, nie allauth
+
+Kit nie zakłada konkretnego pakietu auth dla nowego projektu bez decyzji — allauth i JWT
+to gotowe wzorce do świadomego wyboru (`decisions.auth`), nie ukryty default.
+
+## Powiązane
+
+- `capability:auth` — część wspólna (frontend, testy)
+- `capability:auth:allauth`, `capability:auth:jwt` — gotowe wzorce, jeśli pasują

--- a/modules/capabilities/auth-jwt.md
+++ b/modules/capabilities/auth-jwt.md
@@ -1,0 +1,27 @@
+# Auth — JWT (djangorestframework-simplejwt)
+
+Wariant `decisions.auth: jwt`. Własny `/api/auth/login/`, `/api/auth/refresh/` — access + refresh JWT.
+
+| Aspekt | Implementacja |
+|--------|---------------|
+| Backend | `djangorestframework-simplejwt`, access krótkożyjący, refresh dłuższy (rotacja + blacklist) |
+| Weryfikacja | Domain apps weryfikują token lokalnie (RS256 public key albo shared secret w monolicie) |
+| Web | token w memory/httpOnly cookie (nie `localStorage` — `arch:security`) |
+| Mobile | SecureStore |
+| MFA / social | brak z pudełka — dopisz explicit jeśli potrzebne (`capability:auth:allauth` ma to gotowe) |
+
+## Frontend
+
+Interceptor refresh przy `401`: kolejkuj równoległe requesty podczas odświeżania tokena,
+nie odpalaj wielu równoległych `/refresh/`.
+
+## Orval
+
+Jeden klient, jeden mutator — standardowy DRF schema, mutator dokłada `Authorization: Bearer`
+i obsługuje refresh-on-401 (patrz interceptor wyżej). Brak osobnego auth-schema jak w allauth.
+
+## Powiązane
+
+- `capability:auth` — część wspólna (frontend, testy)
+- `arch:api-contract` — Orval, ogólne zasady kontraktu
+- `arch:security` — przechowywanie tokenów

--- a/modules/capabilities/auth.md
+++ b/modules/capabilities/auth.md
@@ -4,37 +4,20 @@
 
 Uwierzytelnianie użytkownika: login, rejestracja, MFA, social login, sesja.
 
-## Wzorzec referencyjny: django-allauth headless
+## Wybór wariantu backendu
 
-Preferowany dla aplikacji web + mobile (Expo) w kategorii shop / `_base`:
+Wariant wybierasz przez `decisions.auth` w profilu (`allauth` / `jwt` / `custom`,
+domyślnie **`custom`**). Ładuje odpowiedni moduł:
 
-```text
-core/integrations/allauth/    # adaptery, taski cleanup
-apps/accounts/                # Profile, adresy — DRF CRUD (nie logika auth)
-```
+| `decisions.auth` | Moduł | Kiedy |
+|-------------------|-------|-------|
+| `allauth` | `capability:auth:allauth` | django-allauth headless, web + mobile Expo, MFA/social wbudowane |
+| `jwt` | `capability:auth:jwt` | własny `/api/auth/*`, prosty access+refresh, brak potrzeby MFA/social z pudełka |
+| `custom` (default) | `capability:auth:custom` | inny/istniejący mechanizm — opisz kontrakt w `.ai/project.md` |
 
-| Aspekt | Implementacja |
-|--------|---------------|
-| API auth | allauth headless — `_allauth/{browser\|app}/v1/` |
-| Web | cookies + CSRF, `allauthClient = "browser"` |
-| Mobile | `X-Session-Token` + SecureStore, `allauthClient = "app"` |
-| MFA | TOTP, recovery codes, WebAuthn |
-| Social | Google / Facebook via `expo-auth-session` + Dev Client |
-| Profile CRUD | DRF pod ścieżkami customers/accounts (profile, addresses) |
+Nie mieszaj wariantów w tym samym API bez jasnego podziału (np. `pattern:microservices-auth`).
 
-**Orval:** osobny klient z `/_allauth/openapi.json` i mutatorem auth — nie mieszaj z DRF schema.
-
-## Alternatywa: JWT Bearer
-
-Gdy projekt używa własnego `/api/auth/login/` → access + refresh JWT:
-
-- Domain apps weryfikują token lokalnie (RS256 public key).
-- Frontend: interceptor refresh przy 401.
-
-Ten wariant wybieraj świadomie (overlay / fork profilu) — nie mieszaj z allauth headless
-w tym samym API bez jasnego podziału.
-
-## Frontend
+## Frontend (wspólne dla wszystkich wariantów)
 
 ```text
 src/core/auth/        # session, platform (browser/app), storage native/web
@@ -45,10 +28,12 @@ src/features/account/ # profil po zalogowaniu
 ## Testy
 
 - Unit: adapterzy, uprawnienia CRUD profilu.
-- Integration: login browser vs app client headers.
+- Integration: pełny flow login → autoryzowany request → refresh/expiry.
 
 ## Powiązane
 
+- `capability:auth:allauth`, `capability:auth:jwt`, `capability:auth:custom` — wariant backendu
 - `pattern:microservices-auth` — gdy wiele serwisów
 - `domain:shop` — zamówienia wymagają zalogowanego usera
 - `stack:django-drf:structure`
+- `arch:api-contract` — Orval per wariant (patrz moduł wariantu)

--- a/modules/core/repo-first.md
+++ b/modules/core/repo-first.md
@@ -33,6 +33,28 @@ Jeśli instrukcje są sprzeczne, pierwszeństwo ma poziom wyższy.
 5. Propozycja implementacji (jeśli ma sens).
 6. Jeśli czegoś nie dało się potwierdzić — napisz wprost.
 
+## Nowa zasada architektoniczna — dokąd ją zapisać
+
+Zanim zapiszesz nową regułę/wzorzec (nie fakt jednego produktu) — rozstrzygnij:
+
+| Pytanie | TAK → `.ai/project.md` (fakt produktu) | TAK → instruction-kit (reużywalna zasada) |
+| --- | --- | --- |
+| Dotyczy tylko tego repo (nazwa, porty, konkretny provider bez uzasadnienia architektonicznego)? | ✓ | — |
+| Zadziałałaby tak samo w innym projekcie tej samej kategorii (`shop`, `_base`)? | — | ✓ |
+| To nowy wzorzec/standard, nie jednorazowa decyzja biznesowa tego klienta? | — | ✓ |
+
+Reużywalna zasada → **nie** zapisuj wyłącznie w `.ai/project.md`. Zaproponuj zmianę w instruction-kit:
+
+1. Znajdź najbliższy istniejący moduł (`modules/**`) — rozszerz go, jeśli tematycznie pasuje.
+2. Brak pasującego modułu → zaproponuj nowy (+ wpis w `manifest.yaml`, ew. `profiles/*.yaml`).
+3. Instruction-kit to **osobne repo** — przed edycją zapytaj użytkownika, gdzie ono lokalnie leży
+   (ścieżka z `--from` w `mcp.json`, albo wprost zapytaj) i potwierdź zanim tam coś zmienisz.
+4. W `.ai/project.md` zostaw wtedy tylko odnośnik, nie kopię treści:
+   `patrz instruction-kit: capability:X` — nie duplikuj tekstu w dwóch repo naraz.
+
+Bez tego kroku reguły reużywalne rozjeżdżają się po projektach jako lokalne kopie w `.ai/project.md`
+zamiast żyć w jednym miejscu, które inne projekty dziedziczą przez `--preset`/`extends`.
+
 ## Higiena repozytorium
 
 - Nie commituj cache, coverage, logów, `.env`, `.venv`, `node_modules`, build outputów.

--- a/modules/core/repo-first.md
+++ b/modules/core/repo-first.md
@@ -55,6 +55,21 @@ Reużywalna zasada → **nie** zapisuj wyłącznie w `.ai/project.md`. Zaproponu
 Bez tego kroku reguły reużywalne rozjeżdżają się po projektach jako lokalne kopie w `.ai/project.md`
 zamiast żyć w jednym miejscu, które inne projekty dziedziczą przez `--preset`/`extends`.
 
+## Sprawdź synchronizację kita
+
+Na początku pracy (pierwsza wiadomość w sesji dotycząca kodu/architektury — nie przy
+czysto konwersacyjnych pytaniach) zawołaj MCP tool `check_kit_status` **raz**. Tanie —
+jedno porównanie commitów, nie czytanie treści modułów, nie polling w trakcie sesji.
+
+- Wynik "aktualny" / "brak stampu" / "brak historii git" → nic nie rób, kontynuuj normalnie.
+- Wynik "ZMIENIŁ SIĘ" (+ lista plików) → **poinformuj usera** jednym zdaniem i zapytaj czy
+  odpalić `bootstrap-project.sh` ponownie (te same flagi co poprzednio, patrz
+  `.ai/.kit-bootstrap.json`). **Nie** odpalaj bootstrapa sam bez zgody — nadpisuje
+  `.claude/agents/`, `.cursor/agents/`, `.claude/commands/`, `mcp.json`, co może
+  skasować lokalne ręczne edycje tych plików.
+
+Nie wołaj ponownie w tej samej sesji bez powodu — raz na start pracy wystarczy.
+
 ## Higiena repozytorium
 
 - Nie commituj cache, coverage, logów, `.env`, `.venv`, `node_modules`, build outputów.

--- a/modules/core/tooling-rtk.md
+++ b/modules/core/tooling-rtk.md
@@ -1,0 +1,23 @@
+# Shell proxy — RTK (jeśli dostępny)
+
+Przed wykonaniem komend shell (git, testy, grep/find, listowanie plików, docker, gh, itp.)
+sprawdź czy w `PATH` jest dostępny CLI `rtk` (Rust Token Killer).
+
+- **Jeśli `rtk` istnieje:** prefiksuj nim komendy developerskie, np. `rtk git status`,
+  `rtk grep "pattern" src/`, `rtk docker ps`, `rtk gh pr list`. RTK filtruje/kompresuje
+  output przed trafieniem do kontekstu — 60–90% oszczędności tokenów na typowych
+  operacjach dev.
+- **Jeśli `rtk` nie istnieje:** wykonuj komendy normalnie (bez prefiksu) — nie instaluj
+  go, nie traktuj braku jako błędu.
+- **Meta-komendy** (zawsze bez filtrowania, wołane bezpośrednio): `rtk gain`,
+  `rtk gain --history`, `rtk discover`, `rtk proxy <cmd>` (raw, debug).
+- Nie myl z narzędziem o tej samej nazwie (`reachingforthejack/rtk` — Rust Type Kit) —
+  jeśli `rtk --version` / `rtk gain` nie działa, to zły binarny `rtk`, pomiń prefiksowanie.
+
+Zasada ogólna (nie zależy od presetu/domeny) — dotyczy każdego projektu bootstrapowanego
+tym kitem, niezależnie od `--preset`.
+
+Świadomy wyjątek od `core:repo-first` / "Nowa zasada architektoniczna — dokąd ją zapisać":
+to preferencja operatora kita, nie fakt jednego produktu ani zasada specyficzna dla kategorii —
+zostaje w `core:*` bo jest bezpieczna (no-op gdy `rtk` nie ma w PATH) i ma obowiązywać wszędzie
+gdzie ten kit jest używany, niezależnie od projektu.

--- a/modules/infra/search/meilisearch.md
+++ b/modules/infra/search/meilisearch.md
@@ -1,0 +1,27 @@
+# Search — Meilisearch
+
+Wariant `decisions.search: meilisearch`. Wybieraj świadomie, gdy Postgres `tsvector`
+(`infra:search:postgres`) realnie nie wystarcza — duży katalog, faceted search z agregacjami
+liczonymi na żywo, tolerancja literówek out-of-the-box.
+
+## Struktura
+
+- Osobny serwis w `docker-compose.dev/test/prod.yml` (`arch:docker-structure`) — kontener
+  Meilisearch, wolumen na indeks.
+- Indeksowanie: sygnał `post_save`/`post_delete` na modelu produktu → task Celery →
+  `index.add_documents()`/`index.delete_document()`. Nie synchronicznie w request/response.
+- Reindeks pełny jako osobny task/task management command — potrzebny po zmianie schematu
+  atrybutów filtrowalnych.
+
+## Zasady
+
+1. Postgres pozostaje źródłem prawdy (system of record) — Meilisearch to tylko indeks do
+   odczytu, zawsze odtwarzalny z DB. Nigdy nie pisz do Meilisearch jako jedynego miejsca danych.
+2. Filtrowalne/sortowalne atrybuty (`filterableAttributes`, `sortableAttributes`) deklaruj
+   explicit w konfiguracji indeksu — nie każde pole domyślnie.
+3. Klucz API search-only (read-only) dla frontendu, klucz admin tylko po stronie backendu.
+
+## Powiązane
+
+- `infra:search:postgres` — prostszy default, sprawdź zanim tu przejdziesz
+- `arch:docker-structure` — serwis w compose

--- a/modules/infra/search/postgres.md
+++ b/modules/infra/search/postgres.md
@@ -1,0 +1,43 @@
+# Search — Postgres full-text (`tsvector`)
+
+Wariant `decisions.search: postgres` (**default** rekomendowany dla małego/średniego katalogu —
+nie dokładaj osobnego silnika search bez realnej potrzeby).
+
+## Różnica vs `django-filter`
+
+`django-filter` = **strukturalne** filtrowanie po polach (`price__gte=100`, `category=5`) —
+dokładne dopasowanie, SQL `WHERE`, przyspieszone zwykłym DB index (`db_index=True`).
+
+Full-text search = **inny problem**: zapytanie tekstowe użytkownika (literówki, ranking
+trafności po wielu polach naraz — nazwa > opis > tagi), nie dokładne dopasowanie.
+DB index na pojedynczej kolumnie tego nie daje.
+
+## Implementacja
+
+```python
+from django.contrib.postgres.search import SearchVector, SearchVectorField
+from django.contrib.postgres.indexes import GinIndex
+
+class Product(models.Model):
+    search_vector = SearchVectorField(null=True)
+
+    class Meta:
+        indexes = [GinIndex(fields=["search_vector"])]
+```
+
+- Aktualizuj `search_vector` sygnałem `post_save` albo trigger DB (nie w każdym query).
+- Ranking: `SearchRank` + wagi per pole (`A` nazwa, `B` opis, `C` tagi).
+- Literówki: `pg_trgm` (`TrigramSimilarity`) jako fallback gdy `tsvector` nic nie zwróci.
+
+## Kiedy to nie wystarczy
+
+Przy dużym katalogu i realnej potrzebie facetów liczonych na żywo (agregacje po wielu
+atrybutach jednocześnie, sub-100ms) → `decisions.search: meilisearch`
+(`infra:search:meilisearch`). Nie przełączaj się zanim `tsvector` faktycznie nie wystarcza —
+dodatkowy serwis to dodatkowy operacyjny koszt.
+
+## Powiązane
+
+- `arch:migrations` — indeksy i performance ORM
+- `domain:shop` — katalog produktów
+- `infra:search:meilisearch` — alternatywa przy większej skali

--- a/modules/patterns/webhooks.md
+++ b/modules/patterns/webhooks.md
@@ -1,0 +1,38 @@
+# Pattern — Webhooks (przychodzące, od zewnętrznych serwisów)
+
+## Zakres
+
+Zewnętrzny serwis (Stripe, allauth social login callback, inny provider) sam wysyła `POST`
+gdy coś się wydarzy — Ty nie pytasz, oni budzą Twój endpoint. Ten moduł to checklista
+stosowana **za każdym razem** gdy dodajesz nowy webhook, nie tylko przy płatnościach.
+
+## Checklist (obowiązkowa dla każdego webhooka)
+
+1. **Weryfikacja podpisu** — sprawdź nagłówek podpisu (np. `Stripe-Signature`) przed
+   przetworzeniem payloadu. Bez tego ktokolwiek może POST-ować fałszywe eventy na Twój endpoint.
+2. **Idempotency** — zapisz `event_id` z każdego przetworzonego eventu (unique constraint w DB).
+   Provider **wysyła ten sam event wielokrotnie** (retry przy timeout/5xx) — bez flagi
+   "już przetworzony" dostajesz podwójne zamówienia, podwójne maile, podwójne uznanie płatności.
+3. **Szybki `200` + przetwarzanie async** — handler HTTP tylko waliduje podpis i wrzuca task
+   do Celery, zwraca `200` natychmiast. Wolny handler → provider uznaje timeout → retry →
+   duplikaty (patrz punkt 2).
+4. **Brak założeń o kolejności** — eventy mogą przyjść w innej kolejności niż się wydarzyły
+   (np. `refund` przed `payment_succeeded` przy bliskich czasowo akcjach). Stan licz z
+   `event.created`/timestamp z payloadu, nie z kolejności HTTP requestów.
+5. **Log surowego payloadu** — zapisz cały request body (osobna tabela/tabela audytu) zanim
+   zaczniesz przetwarzanie. Bez tego nie zdebugujesz sporu (Stripe dispute) po czasie, gdy UI
+   providera już nie pokazuje szczegółów.
+6. **Dead-letter po N nieudanych retry** — jeśli przetwarzanie stale failuje, event ląduje w
+   kolejce/tabeli do ręcznego przeglądu, nie znika cicho.
+
+## Testy
+
+- Mock podpisu w adapterze (nie live API providera) — `arch:ci-cd`.
+- Test duplikatu: ten sam `event_id` wysłany 2x → efekt uboczny (np. utworzone zamówienie) tylko raz.
+- Test out-of-order: `refund` przed `payment_succeeded` nie psuje stanu końcowego.
+
+## Powiązane
+
+- `capability:payments` — Stripe webhooks konkretnie
+- `capability:auth:allauth` — social login callbacks mają te same pułapki (idempotency, podpis)
+- `arch:observability` — korelacja logów przy debugowaniu sporu

--- a/profiles/_base.yaml
+++ b/profiles/_base.yaml
@@ -16,3 +16,5 @@ bundles:
   architecture:
     - pattern:capability-provider
     - arch:ci-cd
+    - arch:taskfile
+    - arch:docker-structure

--- a/profiles/shop.yaml
+++ b/profiles/shop.yaml
@@ -23,6 +23,11 @@ decisions:
   queue: redis
   storage: s3
   tasks: celery
+  auth: allauth
+  search: postgres
+
+patterns:
+  - webhooks
 
 bundles:
   backend:
@@ -30,6 +35,7 @@ bundles:
     - capability:files
     - capability:payments
     - domain:shop
+    - pattern:webhooks
   frontend:
     - capability:auth
     - capability:payments

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -19,6 +19,9 @@ Użycie: bootstrap-project.sh TARGET_DIR [opcje]
 Opcje:
   --preset NAME       Kategoria z kita (domyślnie: _base). Przykład: shop
   --language LANG     Język prozy instrukcji: pl|en (domyślnie: pl). Tytuły issue/PR zawsze EN
+  --codegen NAME      Generator klienta API: orval (schema → frontend/src/api/generated
+                      + mutatory) | none (tool-agnostyczny/ręczny) | graphql (GraphQL zamiast
+                      REST). Domyślnie: orval
   --clients LIST      all | cursor | claude | codex | vscode | kiro | kilo | antigravity | opencode
                       (lista po przecinku; alias: copilot→vscode). Domyślnie: all
   --from SOURCE       Źródło uvx: ścieżka lokalna lub git+https://… (domyślnie: placeholder GitHub)
@@ -47,6 +50,7 @@ EOF
 TARGET=""
 PRESET="_base"
 LANGUAGE="pl"
+CODEGEN="orval"
 CLIENTS_RAW="all"
 FROM_SRC="git+https://github.com/TWOJ_USER/ai-instruction-kit-mcp.git"
 WITH_PROFILE=0
@@ -69,6 +73,14 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --clients) CLIENTS_RAW="${2:?}"; shift 2 ;;
+    --codegen)
+      CODEGEN="$(echo "${2:?}" | tr '[:upper:]' '[:lower:]')"
+      if [[ "$CODEGEN" != "orval" && "$CODEGEN" != "none" && "$CODEGEN" != "graphql" ]]; then
+        echo "Nieprawidłowy --codegen: $CODEGEN (dozwolone: orval, none, graphql)" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     --from) FROM_SRC="${2:?}"; shift 2 ;;
     --with-profile) WITH_PROFILE=1; shift ;;
     --with-overlay) WITH_OVERLAY=1; shift ;;
@@ -160,7 +172,8 @@ client_enabled() {
 fill_mcp() {
   local src="$1" dest="$2" workspace_repl="${3:-}"
   mkdir -p "$(dirname "$dest")"
-  FROM_SRC="$FROM_SRC" PRESET="$PRESET" LANGUAGE="$LANGUAGE" CLIENTS_ARG="$CLIENTS_ARG" \
+  FROM_SRC="$FROM_SRC" PRESET="$PRESET" LANGUAGE="$LANGUAGE" CODEGEN="$CODEGEN" \
+  CLIENTS_ARG="$CLIENTS_ARG" \
   WORKSPACE_REPL="$workspace_repl" SRC="$src" DEST="$dest" "$PYTHON_BIN" - <<'PY'
 import os
 import re
@@ -181,6 +194,11 @@ text = re.sub(
 text = re.sub(
     r'("--language",\s*")[^"]*(")',
     rf'\g<1>{os.environ["LANGUAGE"]}\2',
+    text,
+)
+text = re.sub(
+    r'("--codegen",\s*")[^"]*(")',
+    rf'\g<1>{os.environ["CODEGEN"]}\2',
     text,
 )
 text = re.sub(
@@ -406,6 +424,7 @@ install_git_pre_push_reminder() {
 echo "Bootstrap instruction-kit → $TARGET"
 echo "  preset=$PRESET"
 echo "  language=$LANGUAGE"
+echo "  codegen=$CODEGEN"
 echo "  clients=$CLIENTS_ARG"
 echo "  from=$FROM_SRC"
 
@@ -465,4 +484,4 @@ echo "Slash: /git-start, /git-check, /git-commit, /git-end, /review-*, /subagent
 if client_enabled cursor; then
   echo "Slash (Cursor): /compact (= Summarize; nie dla Claude/Codex)"
 fi
-echo "MCP: --preset ${PRESET} --language ${LANGUAGE} --clients ${CLIENTS_ARG} --workspace …"
+echo "MCP: --preset ${PRESET} --language ${LANGUAGE} --codegen ${CODEGEN} --clients ${CLIENTS_ARG} --workspace …"

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -31,6 +31,9 @@ Opcje:
   --with-plugins      Best-effort doinstaluj zewnętrzne pluginy (mattpocock skills przez npx;
                       Superpowers/Autopilot tylko instrukcja — to marketplace pluginów Claude/Cursor,
                       nie da się zainstalować z skryptu). Wymaga npx w PATH (Node.js)
+  --keep-unselected-clients
+                      Nie usuwaj plików klientów spoza --clients (domyślnie: sprzątane —
+                      declarative sync, np. --clients claude usuwa .cursor/.codex/… kitowe pliki)
   -h, --help          Ta pomoc
 
 Przykład (tylko Cursor):
@@ -57,6 +60,7 @@ WITH_PROFILE=0
 WITH_OVERLAY=0
 SKIP_AGENTS=0
 WITH_PLUGINS=0
+PRUNE_CLIENTS=1
 
 KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SHARED_AGENTS="$KIT_ROOT/templates/shared/agents"
@@ -86,6 +90,7 @@ while [[ $# -gt 0 ]]; do
     --with-overlay) WITH_OVERLAY=1; shift ;;
     --skip-agents) SKIP_AGENTS=1; shift ;;
     --with-plugins) WITH_PLUGINS=1; shift ;;
+    --keep-unselected-clients) PRUNE_CLIENTS=0; shift ;;
     -h|--help) usage; exit 0 ;;
     -*)
       echo "Nieznana opcja: $1" >&2
@@ -166,6 +171,70 @@ client_enabled() {
     [[ "$c" == "$want" ]] && return 0
   done
   return 1
+}
+
+# Usuwa TYLKO pliki/foldery, które ten sam bootstrap sam kiedyś wygenerował dla danego
+# klienta (mapa 1:1 z install_*() niżej). Nigdy nie rusza sąsiednich plików tego samego
+# katalogu spoza kita (np. .vscode/settings.json, .github/workflows/, .kilocode/rules/).
+prune_client() {
+  local id="$1"
+  case "$id" in
+    cursor)
+      rm -f "$TARGET/.cursor/mcp.json" "$TARGET/.cursor/hooks.json" \
+        "$TARGET/.cursor/hooks/gate-push.sh" "$TARGET/.cursor/hooks/gate-destructive.sh" \
+        "$TARGET/.cursor/hooks/invoke-hook.js" \
+        "$TARGET/.cursor/rules/use-guides.mdc" "$TARGET/.cursor/rules/code-review.mdc" \
+        "$TARGET/.cursor/rules/git-branch-pr.mdc" "$TARGET/.cursor/BUGBOT.md"
+      rm -rf "$TARGET/.cursor/agents" "$TARGET/.cursor/skills"
+      rmdir "$TARGET/.cursor/hooks" "$TARGET/.cursor/rules" "$TARGET/.cursor" 2>/dev/null || true
+      ;;
+    claude)
+      rm -f "$TARGET/.mcp.json"
+      rm -rf "$TARGET/.claude/agents" "$TARGET/.claude/commands"
+      rmdir "$TARGET/.claude" 2>/dev/null || true
+      ;;
+    codex)
+      rm -f "$TARGET/.codex/config.toml"
+      rm -rf "$TARGET/.codex/agents"
+      rmdir "$TARGET/.codex" 2>/dev/null || true
+      ;;
+    vscode)
+      rm -f "$TARGET/.vscode/mcp.json" "$TARGET/.github/copilot-instructions.md"
+      if [[ -d "$TARGET/.github/prompts" ]]; then
+        rm -f "$TARGET/.github/prompts/"*.prompt.md 2>/dev/null || true
+        rmdir "$TARGET/.github/prompts" 2>/dev/null || true
+      fi
+      rmdir "$TARGET/.vscode" 2>/dev/null || true
+      ;;
+    kiro)
+      rm -f "$TARGET/.kiro/settings/mcp.json" "$TARGET/.kiro/steering/instruction-kit.md"
+      rm -rf "$TARGET/.kiro/agents"
+      rmdir "$TARGET/.kiro/settings" "$TARGET/.kiro/steering" "$TARGET/.kiro" 2>/dev/null || true
+      ;;
+    kilo)
+      rm -f "$TARGET/.kilocode/mcp.json"
+      rm -rf "$TARGET/.kilocode/workflows"
+      rmdir "$TARGET/.kilocode" 2>/dev/null || true
+      ;;
+    antigravity)
+      rm -f "$TARGET/.agents/mcp_config.json"
+      rm -rf "$TARGET/.agents/workflows"
+      rmdir "$TARGET/.agents" 2>/dev/null || true
+      ;;
+    opencode)
+      rm -f "$TARGET/opencode.json"
+      rm -rf "$TARGET/.opencode"
+      ;;
+  esac
+}
+
+prune_unselected_clients() {
+  local id
+  for id in cursor claude codex vscode kiro kilo antigravity opencode; do
+    if ! client_enabled "$id"; then
+      prune_client "$id"
+    fi
+  done
 }
 
 # Wypełnij szablon MCP (JSON/TOML): from, preset, language, clients, opcjonalnie workspace.
@@ -430,6 +499,11 @@ echo "  from=$FROM_SRC"
 
 mkdir -p "$TARGET/.ai"
 install_agenty_md_once
+
+if [[ "$PRUNE_CLIENTS" -eq 1 ]]; then
+  prune_unselected_clients
+  echo "  (sprzątnięto kitowe pliki klientów spoza --clients ${CLIENTS_ARG}; wyłącz: --keep-unselected-clients)"
+fi
 
 NEED_GIT_HOOK=0
 for c in "${CLIENTS_LIST[@]}"; do

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -551,6 +551,24 @@ if [[ "$WITH_PLUGINS" -eq 1 ]]; then
   install_plugins
 fi
 
+# Stamp — commit kita w momencie bootstrapu, do taniego "czy trzeba re-bootstrapować"
+# (MCP tool check_kit_status). Pusty kit_commit gdy --from to zdalny URL / nie-git.
+KIT_COMMIT="$(git -C "$KIT_ROOT" rev-parse HEAD 2>/dev/null || true)"
+BOOTSTRAPPED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mkdir -p "$TARGET/.ai"
+cat > "$TARGET/.ai/.kit-bootstrap.json" <<JSON
+{
+  "kit_commit": "${KIT_COMMIT}",
+  "kit_from": "${FROM_SRC}",
+  "bootstrapped_at": "${BOOTSTRAPPED_AT}",
+  "preset": "${PRESET}",
+  "language": "${LANGUAGE}",
+  "codegen": "${CODEGEN}",
+  "clients": "${CLIENTS_ARG}"
+}
+JSON
+echo "  + .ai/.kit-bootstrap.json (stamp dla check_kit_status)"
+
 echo ""
 echo "Gotowe. Zrestartuj IDE w $TARGET."
 echo "Clients: ${CLIENTS_ARG}"

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -311,6 +311,17 @@ install_agenty_md_once() {
   fi
 }
 
+# BUGBOT.md w root — niezależnie od --clients, bo /review-bugbot (manualny odpowiednik)
+# ma działać dla WSZYSTKICH klientów (Claude, Codex, VS Code…), nie tylko Cursor.
+# .cursor/BUGBOT.md (install_cursor) zostaje osobno — to dla natywnej usługi Cursor
+# BugBot, która czyta z tamtej ścieżki; ta funkcja to nie duplikat, to inny konsument.
+install_bugbot_md_once() {
+  if [[ ! -f "$TARGET/BUGBOT.md" ]]; then
+    cp "$KIT_ROOT/templates/cursor/BUGBOT.md" "$TARGET/BUGBOT.md"
+    echo "  + BUGBOT.md (root — dla /review-bugbot wszystkich klientów)"
+  fi
+}
+
 install_cursor() {
   mkdir -p "$TARGET/.cursor/hooks" "$TARGET/.cursor/rules" "$TARGET/.ai"
   fill_mcp "$KIT_ROOT/templates/cursor/mcp.json" "$TARGET/.cursor/mcp.json"
@@ -499,6 +510,7 @@ echo "  from=$FROM_SRC"
 
 mkdir -p "$TARGET/.ai"
 install_agenty_md_once
+install_bugbot_md_once
 
 if [[ "$PRUNE_CLIENTS" -eq 1 ]]; then
   prune_unselected_clients

--- a/src/guides/kit_status.py
+++ b/src/guides/kit_status.py
@@ -1,0 +1,140 @@
+"""Tani status "czy kit się zmienił od bootstrapu" — bez czytania treści modułów."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+STAMP_REL_PATH = ".ai/.kit-bootstrap.json"
+
+# Ścieżki które bootstrap-project.sh faktycznie kopiuje/renderuje do konsumenta —
+# tylko te obchodzą "czy trzeba re-bootstrapować" (treść modules/*.md kit czyta live,
+# nie kopiuje, więc nie wchodzi do tej listy).
+_TRACKED_GLOBS: tuple[str, ...] = (
+    "templates/shared/agents/*.md",
+    "templates/*/mcp.json",
+    "templates/*/mcp_config.json",
+    "templates/codex/config.toml",
+    "templates/opencode/opencode.json",
+    "templates/AGENTS.md",
+    "templates/project.md",
+    "scripts/bootstrap-project.sh",
+    "scripts/render_agent_commands.py",
+)
+
+
+def _read_stamp(workspace_root: Path) -> dict | None:
+    path = workspace_root / STAMP_REL_PATH
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _git(kit_root: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(kit_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
+    """
+    Porównaj commit kita zapisany przy ostatnim bootstrapie z aktualnym HEAD.
+
+    Tanie: tylko `git rev-parse`/`git diff --name-only` na kicie + jeden odczyt
+    pliku stamp — bez czytania treści modułów instrukcji.
+
+    Args:
+        kit_root: Root instruction-kit (lokalny klon, z --from/kit_root MCP).
+        workspace_root: Root repo aplikacji (gdzie leży `.ai/.kit-bootstrap.json`).
+
+    Returns:
+        str: Markdown — status "aktualny" / "kit się zmienił" / brak stampu / brak
+            lokalnej historii git do porównania.
+    """
+    stamp = _read_stamp(workspace_root)
+    if stamp is None:
+        return (
+            "# Kit status: brak stampu\n\n"
+            f"Nie znaleziono `{STAMP_REL_PATH}` w repo aplikacji — projekt nie był "
+            "bootstrapowany wersją kita ze stampem (albo plik usunięty). "
+            "Uruchom `bootstrap-project.sh` żeby go założyć."
+        )
+
+    stamp_commit = stamp.get("kit_commit") or ""
+    kit_from = stamp.get("kit_from", "—")
+    bootstrapped_at = stamp.get("bootstrapped_at", "—")
+
+    if not stamp_commit:
+        return (
+            "# Kit status: brak historii git\n\n"
+            f"Kit źródło: `{kit_from}` (nie lokalny klon git przy bootstrapie — "
+            "brak commitu do porównania). Re-bootstrapuj ręcznie okresowo, albo "
+            "sklonuj kit lokalnie żeby dostać porównanie."
+        )
+
+    current_commit = _git(kit_root, "rev-parse", "HEAD")
+    if current_commit is None:
+        return (
+            "# Kit status: kit_root nie jest (już) repo git\n\n"
+            f"Ścieżka: `{kit_root}`. Nie można porównać — sprawdź ręcznie."
+        )
+
+    if current_commit == stamp_commit:
+        return (
+            "# Kit status: aktualny\n\n"
+            f"- Bootstrapowano: {bootstrapped_at}\n"
+            f"- Commit: `{stamp_commit[:12]}`\n"
+            "- Nic nowego w kicie od ostatniego bootstrapu."
+        )
+
+    count = _git(kit_root, "rev-list", "--count", f"{stamp_commit}..{current_commit}")
+    changed_files: list[str] = []
+    for pattern in _TRACKED_GLOBS:
+        out = _git(
+            kit_root, "diff", "--name-only", f"{stamp_commit}..{current_commit}", "--", pattern
+        )
+        if out:
+            changed_files.extend(line for line in out.splitlines() if line)
+
+    lines = [
+        "# Kit status: ZMIENIŁ SIĘ od ostatniego bootstrapu",
+        "",
+        f"- Bootstrapowano: {bootstrapped_at} (`{stamp_commit[:12]}`)",
+        f"- Teraz: `{current_commit[:12]}`"
+        + (f" ({count} commitów później)" if count else ""),
+        "",
+    ]
+    if changed_files:
+        lines.append("## Pliki które re-bootstrap by nadpisał:")
+        lines.append("")
+        lines.extend(f"- `{f}`" for f in sorted(set(changed_files)))
+        lines.append("")
+        lines.append(
+            "Uruchom ponownie `bootstrap-project.sh` (te same flagi co poprzednio) "
+            "żeby dostać aktualizację. **Nadpisze** `.claude/agents/`, `.cursor/agents/`, "
+            "`.claude/commands/`, `mcp.json` — jeśli je ręcznie edytowałeś, zrób "
+            "`git diff` najpierw."
+        )
+    else:
+        lines.append(
+            "Kit ma nowe commity, ale żaden nie dotyka plików które bootstrap kopiuje "
+            "do tego repo (agents/commands/mcp.json) — re-bootstrap niepotrzebny. "
+            "Moduły instrukcji (`modules/*.md`) i tak są czytane live, bez kopii."
+        )
+
+    return "\n".join(lines)

--- a/src/guides/resolver.py
+++ b/src/guides/resolver.py
@@ -14,6 +14,27 @@ LANGUAGE_MODULE_IDS: frozenset[str] = frozenset(
     {"core:language-pl", "core:language-en"}
 )
 
+CODEGEN_VALUES: frozenset[str] = frozenset({"orval", "none", "graphql"})
+
+
+def normalize_codegen(raw: str | None) -> str:
+    """
+    Znormalizuj wybór generatora klienta API do ``orval`` / ``none`` / ``graphql``.
+
+    Args:
+        raw: Wartość z CLI/env/profilu YAML (dowolny case, może być ``None``).
+
+    Returns:
+        str: ``orval`` (Orval — schema → `frontend/src/api/generated` + mutatory,
+            **default**), ``none`` (tool-agnostyczny wygenerowany klient REST — konkret
+            w overlay projektu) albo ``graphql`` (GraphQL zamiast REST — patrz
+            `arch:api-contract:graphql`).
+    """
+    if raw is None:
+        return "orval"
+    value = raw.strip().lower()
+    return value if value in CODEGEN_VALUES else "orval"
+
 
 def normalize_language(raw: str | None) -> str:
     """
@@ -47,6 +68,76 @@ def language_module_id(language: str) -> str:
         str: ``core:language-en`` albo ``core:language-pl``.
     """
     return "core:language-en" if language == "en" else "core:language-pl"
+
+
+AUTH_VARIANT_VALUES: frozenset[str] = frozenset({"allauth", "jwt", "custom"})
+
+_AUTH_VARIANT_MODULES: dict[str, str] = {
+    "allauth": "capability:auth:allauth",
+    "jwt": "capability:auth:jwt",
+    "custom": "capability:auth:custom",
+}
+
+
+def normalize_auth_variant(raw: object | None) -> str:
+    """
+    Znormalizuj wybór wariantu auth do ``allauth`` / ``jwt`` / ``custom``.
+
+    Args:
+        raw: Wartość ``decisions.auth`` z profilu — spodziewany string (dowolny case),
+            ale YAML może dać ``None``/bool/int (np. niecudzysłowione ``auth: true``).
+
+    Returns:
+        str: Jeden z ``AUTH_VARIANT_VALUES``; ``None``, nie-string albo nierozpoznana
+            wartość → ``custom``.
+    """
+    if not isinstance(raw, str):
+        return "custom"
+    value = raw.strip().lower()
+    return value if value in AUTH_VARIANT_VALUES else "custom"
+
+
+def _apply_auth_variant(module_ids: list[str], auth_variant: str) -> list[str]:
+    """
+    Dopisz wariant backendu auth zaraz po ``capability:auth``, jeśli ten jest na liście.
+
+    Args:
+        module_ids: Lista ID modułów bundle'a/profilu.
+        auth_variant: Znormalizowany wariant (wynik ``normalize_auth_variant``).
+
+    Returns:
+        list[str]: Lista z dopisanym ``capability:auth:{allauth|jwt|custom}``
+            zaraz po każdym wystąpieniu ``capability:auth``.
+    """
+    variant_id = _AUTH_VARIANT_MODULES[auth_variant]
+    result: list[str] = []
+    for module_id in module_ids:
+        result.append(module_id)
+        if module_id == "capability:auth":
+            result.append(variant_id)
+    return result
+
+
+def _apply_codegen(module_ids: list[str], codegen: str) -> list[str]:
+    """
+    Podmień ``arch:api-contract`` na wariant zależny od wybranego generatora klienta API.
+
+    Args:
+        module_ids: Lista ID modułów bundle'a.
+        codegen: Znormalizowany wybór (``orval`` / ``none`` / ``graphql``,
+            wynik ``normalize_codegen``).
+
+    Returns:
+        list[str]: Lista z podmienionym ``arch:api-contract`` na ``arch:api-contract:{codegen}``
+            gdy ``codegen != "orval"``; bez zmian dla ``orval`` (default).
+    """
+    if codegen == "orval":
+        return module_ids
+    variant_id = f"arch:api-contract:{codegen}"
+    return [
+        variant_id if mid == "arch:api-contract" else mid
+        for mid in module_ids
+    ]
 
 
 def _remap_language_modules(module_ids: list[str], language: str) -> list[str]:
@@ -113,6 +204,7 @@ class ResolvedProfile:
 
     name: str
     language: str
+    codegen: str
     kit_root: Path
     profile_path: Path
     workspace_root: Path
@@ -253,7 +345,11 @@ def _decision_module_ids(decisions: dict[str, Any]) -> list[str]:
     Zmapuj sloty decisions z profilu na moduły infra:*.
 
     Sloty:
-        database, cache, queue, storage, tasks
+        database, cache, queue, storage, tasks, search
+
+    Uwaga: slot ``auth`` nie jest tu obsługiwany — ma osobny mechanizm
+    (``_apply_auth_variant``), bo dokleja się do ``capability:auth`` w bundle'ach
+    backend/frontend, nie do infra/devops/full.
     """
     slot_mapping: dict[str, dict[str, str]] = {
         "database": {
@@ -270,6 +366,10 @@ def _decision_module_ids(decisions: dict[str, Any]) -> list[str]:
             "s3": "infra:storage:s3",
             "minio": "infra:storage:s3",
             "aws": "infra:storage:s3",
+        },
+        "search": {
+            "postgres": "infra:search:postgres",
+            "meilisearch": "infra:search:meilisearch",
         },
         "tasks": {
             "celery": "infra:tasks:celery",
@@ -337,6 +437,7 @@ def _collect_module_ids(profile_data: dict[str, Any], manifest: Manifest) -> lis
         "providers-and-settings": "pattern:providers-and-settings",
         "gateway-nginx": "pattern:gateway-nginx",
         "microservices-auth": "pattern:microservices-auth",
+        "webhooks": "pattern:webhooks",
         "repo-first": "core:repo-first",
     }
     for pattern in patterns:
@@ -351,11 +452,14 @@ def _collect_module_ids(profile_data: dict[str, Any], manifest: Manifest) -> lis
     # Domyślnie core jeśli profil nie wyłącza
     if profile_data.get("core", True):
         module_ids = _merge_unique(
-            ["core:repo-first", lang_module, "core:external-knowledge"],
+            ["core:repo-first", lang_module, "core:external-knowledge", "core:tooling-rtk"],
             module_ids,
         )
 
     module_ids = _remap_language_modules(module_ids, language)
+    module_ids = _apply_codegen(module_ids, str(profile_data.get("codegen", "orval")))
+    auth_variant = normalize_auth_variant(profile_data.get("decisions", {}).get("auth"))
+    module_ids = _apply_auth_variant(module_ids, auth_variant)
     module_ids = _normalize_module_ids(module_ids)
 
     # Walidacja — tylko znane moduły
@@ -480,6 +584,7 @@ def resolve_profile(
     workspace_root: Path | None = None,
     extra_overlays: list[Path] | None = None,
     language_override: str | None = None,
+    codegen_override: str | None = None,
 ) -> ResolvedProfile:
     """
     Rozwiąż profil projektu do bundle'i i indeksu.
@@ -492,6 +597,8 @@ def resolve_profile(
         extra_overlays: Dodatkowe pliki overlay z CLI.
         language_override: Nadpisanie języka z CLI/env (``pl`` / ``en``); ma pierwszeństwo
             przed ``language`` w YAML profilu.
+        codegen_override: Nadpisanie generatora klienta API z CLI/env (``orval`` / ``none``);
+            ma pierwszeństwo przed ``codegen`` w YAML profilu.
 
     Returns:
         ResolvedProfile: Gotowe bundle'e i metadane profilu.
@@ -515,7 +622,12 @@ def resolve_profile(
         if language_override is not None
         else str(profile_data.get("language", "pl"))
     )
-    profile_data = {**profile_data, "language": language}
+    codegen = normalize_codegen(
+        codegen_override
+        if codegen_override is not None
+        else str(profile_data.get("codegen", "orval"))
+    )
+    profile_data = {**profile_data, "language": language, "codegen": codegen}
 
     enabled_modules = _collect_module_ids(profile_data, manifest)
 
@@ -524,8 +636,12 @@ def resolve_profile(
         profile_data.get("bundles", {}),
     )
     bundles_config = _inject_infra_bundles(bundles_config, profile_data)
+    auth_variant = normalize_auth_variant(profile_data.get("decisions", {}).get("auth"))
     bundles_config = {
-        name: _remap_language_modules(list(module_ids), language)
+        name: _remap_language_modules(
+            _apply_auth_variant(_apply_codegen(list(module_ids), codegen), auth_variant),
+            language,
+        )
         for name, module_ids in bundles_config.items()
     }
 
@@ -547,6 +663,7 @@ def resolve_profile(
         "",
         f"- Język: {language}",
         f"- Moduł języka: `{language_module_id(language)}`",
+        f"- Codegen: {codegen}",
         f"- Profil: `{profile_path}`",
         f"- Workspace: `{resolved_workspace}`",
         f"- Kit root: `{manifest.kit_root}`",
@@ -569,6 +686,7 @@ def resolve_profile(
     return ResolvedProfile(
         name=str(profile_data.get("name", resolved_workspace.name)),
         language=language,
+        codegen=codegen,
         kit_root=manifest.kit_root,
         profile_path=profile_path,
         workspace_root=resolved_workspace,

--- a/src/guides/server.py
+++ b/src/guides/server.py
@@ -16,6 +16,7 @@ from guides.clients import (
 from guides.manifest import find_kit_root, load_manifest
 from guides.resolver import (
     language_module_id,
+    normalize_codegen,
     normalize_language,
     resolve_preset_path,
     resolve_profile,
@@ -38,6 +39,7 @@ _kit_root: Path | None = None
 _workspace_root: Path | None = None
 _extra_overlays: list[Path] = []
 _language_override: str | None = None
+_codegen_override: str | None = None
 _clients: list[str] = ["all"]
 
 
@@ -61,6 +63,7 @@ def _get_resolved():
         workspace_root=_workspace_root,
         extra_overlays=_extra_overlays or None,
         language_override=_language_override,
+        codegen_override=_codegen_override,
     )
 
 
@@ -168,6 +171,49 @@ def get_language() -> str:
         f"- {chat}",
         "",
         "Source of truth for agents: this tool + the language module inside bundles.",
+    ]
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def get_codegen() -> str:
+    """
+    Aktualny wybór generatora klienta API (``--codegen`` / `codegen:` w profilu).
+
+    Returns:
+        str: Markdown — ``orval`` (schema → `frontend/src/api/generated` + mutatory),
+            ``none`` (tool-agnostyczny klient, konkret w overlay projektu) albo
+            ``graphql`` (GraphQL zamiast REST, patrz `arch:api-contract:graphql`).
+    """
+    resolved = _get_resolved()
+    codegen = resolved.codegen
+    if codegen == "orval":
+        detail = (
+            "**Orval**: `task orval:generate` (nazwa taska zależy od overlay projektu) "
+            "czyta OpenAPI schema i generuje typowanego klienta + mutatory do "
+            "`frontend/src/api/generated/`. Nie edytuj wygenerowanych plików ręcznie."
+        )
+    elif codegen == "graphql":
+        detail = (
+            "**GraphQL** — zamiast REST+OpenAPI. `graphql-codegen` generuje typy z "
+            "`.graphql` query + schema. Osobny pipeline niż Orval — patrz "
+            "`arch:api-contract:graphql`."
+        )
+    else:
+        detail = (
+            "**Brak Orval** — generyczny/tool-agnostyczny klient API albo typy ręczne. "
+            "Konkretne narzędzie i komenda regeneracji — overlay projektu `.ai/project.md`."
+        )
+    module_suffix = {"orval": "", "none": ":none", "graphql": ":graphql"}[codegen]
+    lines = [
+        f"# Codegen: `{codegen}`",
+        "",
+        f"- Override CLI/env: `{_codegen_override or '—'}` "
+        f"(GUIDES_CODEGEN / `--codegen` wygrywa z `codegen:` w profilu; domyślnie `orval`)",
+        "",
+        detail,
+        "",
+        f"Moduł: `arch:api-contract{module_suffix}`.",
     ]
     return "\n".join(lines)
 
@@ -286,7 +332,8 @@ def _register_bundle_resources() -> None:
 
 def main() -> None:
     """Entrypoint CLI serwera MCP."""
-    global _profile_path, _kit_root, _workspace_root, _extra_overlays, _language_override, _clients
+    global _profile_path, _kit_root, _workspace_root, _extra_overlays
+    global _language_override, _codegen_override, _clients
 
     parser = argparse.ArgumentParser(description="Instruction-kit MCP server")
     parser.add_argument(
@@ -315,6 +362,16 @@ def main() -> None:
         required=False,
         choices=("pl", "en", "PL", "EN"),
         help="Język prozy instrukcji (pl|en); tytuły issue/PR zawsze EN. Domyślnie: profil lub pl",
+    )
+    parser.add_argument(
+        "--codegen",
+        required=False,
+        choices=("orval", "none", "graphql", "ORVAL", "NONE", "GRAPHQL"),
+        help=(
+            "Generator klienta API: orval (schema → frontend/src/api/generated + mutatory) "
+            "| none (tool-agnostyczny/ręczny) | graphql (GraphQL zamiast REST). "
+            "Domyślnie: codegen: w profilu albo orval"
+        ),
     )
     parser.add_argument(
         "--kit-root",
@@ -349,6 +406,10 @@ def main() -> None:
     lang_cli = args.language or os.environ.get("GUIDES_LANGUAGE")
     if lang_cli:
         _language_override = normalize_language(lang_cli)
+
+    codegen_cli = args.codegen or os.environ.get("GUIDES_CODEGEN")
+    if codegen_cli:
+        _codegen_override = normalize_codegen(codegen_cli)
 
     clients_raw = args.clients if args.clients is not None else os.environ.get("GUIDES_CLIENTS")
     try:

--- a/src/guides/server.py
+++ b/src/guides/server.py
@@ -13,6 +13,7 @@ from guides.clients import (
     format_clients_arg,
     parse_clients,
 )
+from guides.kit_status import check_kit_updates
 from guides.manifest import find_kit_root, load_manifest
 from guides.resolver import (
     language_module_id,
@@ -216,6 +217,25 @@ def get_codegen() -> str:
         f"Moduł: `arch:api-contract{module_suffix}`.",
     ]
     return "\n".join(lines)
+
+
+@mcp.tool()
+def check_kit_status() -> str:
+    """
+    Sprawdź czy kit zmienił się od ostatniego `bootstrap-project.sh` w tym repo.
+
+    Tanie: porównuje commit zapisany w `.ai/.kit-bootstrap.json` z aktualnym HEAD
+    kita (git rev-parse/diff --name-only) — nie czyta treści modułów instrukcji.
+    Moduły (`modules/*.md`) są i tak czytane live przez `get_bundle`/`get_overlay`,
+    więc nigdy nie "gniją" — ten tool dotyczy tylko plików które bootstrap
+    **kopiuje** (agents/commands/mcp.json), bo te są statyczną migawką.
+
+    Returns:
+        str: Markdown — aktualny / zmienił się (+ lista plików które re-bootstrap
+            by nadpisał) / brak stampu / brak lokalnej historii git do porównania.
+    """
+    resolved = _get_resolved()
+    return check_kit_updates(kit_root=resolved.kit_root, workspace_root=resolved.workspace_root)
 
 
 @mcp.tool()

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -69,7 +69,7 @@ Auth, ACL, billing, migracje, concurrency, brak dowodu w repo → **zapytaj uży
 
 ## Codegen (Orval)
 
-W overlay (`.ai/project.md` / extras) ustaw `codegen: orval` \| `manual` \| `none`.  
+W overlay (`.ai/project.md` / extras) ustaw `codegen: orval` (default) \| `none` \| `graphql`.  
 Docelowo też flaga MCP `--codegen` (design — jeszcze nie w CLI). Review FE/BE honorują tę wartość.  
 
 ## Język

--- a/templates/antigravity/mcp_config.json
+++ b/templates/antigravity/mcp_config.json
@@ -7,6 +7,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${workspaceFolder}"
       ]

--- a/templates/claude/mcp.json
+++ b/templates/claude/mcp.json
@@ -7,6 +7,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${CLAUDE_PROJECT_DIR:-.}"
       ]

--- a/templates/codex/config.toml
+++ b/templates/codex/config.toml
@@ -11,6 +11,7 @@ args = [
   "guides-mcp",
   "--preset", "_base",
   "--language", "pl",
+  "--codegen", "orval",
   "--clients", "all",
   "--workspace", "/ABSOLUTNA/SCIEZKA/DO/PROJEKTU",
 ]

--- a/templates/cursor/mcp.json
+++ b/templates/cursor/mcp.json
@@ -7,6 +7,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${workspaceFolder}"
       ]

--- a/templates/extras.md
+++ b/templates/extras.md
@@ -14,11 +14,11 @@ codegen: orval
 
 | Wartość | Kiedy |
 |---------|--------|
-| `orval` | REST API + FE z wygenerowanym klientem OpenAPI |
-| `manual` | FE ma ręczny klient / fetch — bez Orval |
-| `none` | Brak generowanego klienta (np. tylko Django HTML) |
+| `orval` | REST API + FE z wygenerowanym klientem OpenAPI (default) |
+| `none` | REST bez Orval — generyczny klient innym narzędziem albo ręczny fetch/typy |
+| `graphql` | GraphQL zamiast REST — patrz `arch:api-contract:graphql` |
 
-Docelowo to samo jako flaga MCP: `--codegen orval|manual|none` (jeszcze nie w CLI).
+Docelowo to samo jako flaga MCP: `--codegen orval|none|graphql` (jeszcze nie w CLI).
 
 Gdy `orval`: po zmianie serializera/viewsetu/schema → `task ovral:generate` (lub task z Taskfile poniżej) → commit wygenerowanych plików.
 

--- a/templates/kilo/mcp.json
+++ b/templates/kilo/mcp.json
@@ -7,6 +7,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${workspaceFolder}"
       ]

--- a/templates/kiro/settings/mcp.json
+++ b/templates/kiro/settings/mcp.json
@@ -7,6 +7,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${workspaceFolder}"
       ]

--- a/templates/opencode/opencode.json
+++ b/templates/opencode/opencode.json
@@ -9,6 +9,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "/ABSOLUTNA/SCIEZKA/DO/PROJEKTU"
       ],

--- a/templates/project.md
+++ b/templates/project.md
@@ -1,14 +1,16 @@
 # Overlay projektu — TYLKO unikalne informacje tego repo
 
+> Reużywalna zasada architektoniczna (zadziałałaby w innym projekcie tej samej kategorii)?
+> Nie wpisuj jej tu — zaproponuj zmianę w instruction-kit (`core:repo-first`, sekcja
+> "Nowa zasada architektoniczna — dokąd ją zapisać"). Tu tylko fakty **tego** repo.
+
 ## Codegen
 
-```text
-codegen: orval
-```
+Źródło prawdy: MCP `get_codegen` / flaga `--codegen orval|none|graphql` w `.mcp.json` (nie ten plik).
+Domyślnie `orval`. Przy `orval`: po zmianie API → uruchom komendę regeneracji klienta
+(nazwa taska specyficzna dla tego repo — uzupełnij niżej) → commit klienta.
 
-Warianty: `orval` (domyślnie przy REST+FE) \| `manual` \| `none`.  
-Przy `orval`: po zmianie API → `task ovral:generate` → commit klienta.  
-Docelowa flaga MCP: `--codegen` (design; jeszcze nie w CLI).
+Task regeneracji klienta w tym repo: `<uzupełnij, np. task orval:generate>`.
 
 ## Struktura
 

--- a/templates/shared/agents/git-end.md
+++ b/templates/shared/agents/git-end.md
@@ -20,7 +20,8 @@ Gdy user poda help — wypisz i zakończ (bez push/PR):
 ```markdown
 # /git-end — pomoc
 
-Push bieżącego feature brancha + `gh pr create` z `Closes #N`.
+Push bieżącego feature brancha + `gh pr create` z `Closes #N`. Po pushu wraca na branch
+sprzed `/git-start` (jeśli zapisany), jeśli nie — zostaje na feature branchu.
 
 ## Kiedy
 Po `/git-start`, implementacji, **`/git-commit`** (jeśli były lokalne zmiany) i **Twoim** `/review-*` (napraw findings).
@@ -93,14 +94,32 @@ EOF
 
 Bez `#N`: bez `Closes`. Istniejący PR: `gh pr view --json url -q .url`.
 
-### 4. Raport
+### 4. Powrót na branch sprzed `/git-start`
+
+Po udanym push+PR, **nie zostawaj** na feature branchu — wróć tam skąd user startował:
+
+```bash
+CUR_BRANCH=$(git branch --show-current)
+PREV=$(git config "branch.${CUR_BRANCH}.startedFrom" 2>/dev/null || true)
+if [[ -n "$PREV" ]] && git show-ref --verify --quiet "refs/heads/$PREV"; then
+  git checkout "$PREV"
+fi
+```
+
+Bezpieczne bo **po pushu** — praca feature brancha jest już na remote, nic nie ginie.
+Brak configu (branch stworzony ręcznie, nie przez `/git-start`) albo `PREV` już nie istnieje
+lokalnie → **zostań** na feature branchu, nie zgaduj docelowego (nie myl z `--base` PR-a —
+to inna rzecz, target mergu, nie branch do którego user wraca w IDE).
+
+### 5. Raport
 
 ```markdown
 ## /git-end OK
-- Branch: …
+- Branch: … (branch feature, z którego poszedł push/PR)
 - PR: <url>
-- Base: …
+- Base: … (target PR-a — merge base, nie branch powrotu)
 - Closes: #N
+- IDE teraz na: … (branch powrotu jeśli był zapisany, inaczej nadal branch feature)
 - Dalej: Autopilot → merge gdy green
 ```
 

--- a/templates/shared/agents/git-start.md
+++ b/templates/shared/agents/git-start.md
@@ -102,9 +102,13 @@ Kebab-case ASCII, 3–6 słów.
 git fetch --all --prune 2>/dev/null || true
 git status -sb
 gh repo view --json nameWithOwner,defaultBranchRef -q .
+PREV_BRANCH=$(git branch --show-current)
 ```
 
-Baza: `dev` jeśli istnieje, inaczej default branch.
+Baza: `dev` jeśli istnieje, inaczej default branch. Zapamiętaj `PREV_BRANCH` — to branch na
+którym stał user przed `/git-start` (najczęściej `main`/`master`/`dev`, czasem inny feature
+branch w toku). `/git-end` ma na niego wrócić po push+PR — zapisz go od razu w konfigu nowego
+brancha (krok 2–3), nie tylko w raporcie.
 
 ### 1. Issue
 
@@ -127,6 +131,16 @@ Albo (gdy CLI wspiera): `gh issue create … --json number,url -q .number`.
 Czysty tree + issue: `gh issue develop N --name "…" --base <baza> --checkout`.  
 Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 
+Zaraz po utworzeniu brancha (**każda** ścieżka powyżej), zapisz `PREV_BRANCH` do configu
+lokalnego dla tego brancha — to jedyny sposób żeby `/git-end` wiedział dokąd wrócić:
+
+```bash
+git config branch."<typ>/<N>-<slug>".startedFrom "$PREV_BRANCH"
+```
+
+Pomiń tylko gdy `PREV_BRANCH` jest puste (detached HEAD) — wtedy `/git-end` zostanie na
+feature branchu, bez próby powrotu.
+
 ### 4. Raport
 
 ```markdown
@@ -135,6 +149,7 @@ Brudny: `checkout -b` od `origin/<baza>` jak wyżej.
 - Issue: #N — title — url
 - Branch: …
 - Base: … (wanted / actual)
+- Powrót po `/git-end`: `$PREV_BRANCH` (zapisane w `branch.<nazwa>.startedFrom`)
 - Następne: **`/git-commit`** → review → **`/git-end`** (Ty) → [Autopilot]
 ```
 

--- a/templates/shared/agents/review-bugbot.md
+++ b/templates/shared/agents/review-bugbot.md
@@ -28,8 +28,11 @@ Brak findingów → jedna linia: "Brak uwag wg BUGBOT.md."
 
 W kolejności:
 
-1. `.cursor/BUGBOT.md` (najczęstsze — kopiowane przez bootstrap kita).
-2. `BUGBOT.md` w root repo.
+1. `BUGBOT.md` w root repo (kopiowany przez bootstrap kita **niezależnie od `--clients`** —
+   to ten plik dla wszystkich klientów, nie tylko Cursor).
+2. `.cursor/BUGBOT.md` (kopia dla natywnej usługi Cursor BugBot — istnieje tylko gdy
+   projekt bootstrapowano z `--clients cursor`/`all`; jeśli oba pliki istnieją, oba mają
+   tę samą treść — użyj root, nie czytaj dwa razy).
 3. Brak pliku → powiedz to wprost i zastosuj tylko reguły ogólne z `AGENTS.md` (sekrety, minimalny diff, brak testów).
 
 ### 2. Diff

--- a/templates/vscode/mcp.json
+++ b/templates/vscode/mcp.json
@@ -8,6 +8,7 @@
         "guides-mcp",
         "--preset", "_base",
         "--language", "pl",
+        "--codegen", "orval",
         "--clients", "all",
         "--workspace", "${workspaceFolder}"
       ]

--- a/tests/test_kit_status.py
+++ b/tests/test_kit_status.py
@@ -1,0 +1,147 @@
+"""Testy check_kit_updates — tani status driftu kita vs stamp bootstrapu."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from guides.kit_status import check_kit_updates
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_kit_repo(kit_root: Path) -> None:
+    kit_root.mkdir(parents=True, exist_ok=True)
+    _git(kit_root, "init", "-q")
+    _git(kit_root, "config", "user.email", "test@test.local")
+    _git(kit_root, "config", "user.name", "test")
+    agents_dir = kit_root / "templates" / "shared" / "agents"
+    agents_dir.mkdir(parents=True)
+    (agents_dir / "git-start.md").write_text("v1\n", encoding="utf-8")
+    (kit_root / "unrelated.md").write_text("noise\n", encoding="utf-8")
+    _git(kit_root, "add", "-A")
+    _git(kit_root, "commit", "-q", "-m", "initial")
+
+
+def _head(kit_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(kit_root), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_stamp(workspace: Path, kit_commit: str, kit_from: str = "local") -> None:
+    ai_dir = workspace / ".ai"
+    ai_dir.mkdir(parents=True, exist_ok=True)
+    (ai_dir / ".kit-bootstrap.json").write_text(
+        json.dumps(
+            {
+                "kit_commit": kit_commit,
+                "kit_from": kit_from,
+                "bootstrapped_at": "2026-01-01T00:00:00Z",
+                "preset": "_base",
+                "language": "pl",
+                "codegen": "orval",
+                "clients": "all",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestKitStatus(unittest.TestCase):
+    def test_no_stamp_reports_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            workspace.mkdir()
+            _init_kit_repo(kit_root)
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("brak stampu", out)
+
+    def test_empty_kit_commit_reports_no_history(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit="", kit_from="git+https://example.com/kit.git")
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("brak historii git", out)
+
+    def test_up_to_date(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("aktualny", out)
+
+    def test_changed_tracked_file_lists_it(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            (kit_root / "templates" / "shared" / "agents" / "git-start.md").write_text(
+                "v2\n", encoding="utf-8"
+            )
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "update git-start")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("ZMIENIŁ SIĘ", out)
+            self.assertIn("templates/shared/agents/git-start.md", out)
+
+    def test_changed_untracked_file_no_rebootstrap_needed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            (kit_root / "unrelated.md").write_text("more noise\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "unrelated change")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("ZMIENIŁ SIĘ", out)
+            self.assertIn("re-bootstrap niepotrzebny", out)
+            self.assertNotIn("unrelated.md", out)
+
+    def test_net_zero_change_shows_no_tracked_diff(self) -> None:
+        """Commit + revert netto się znoszą — diff --name-only nic nie pokaże."""
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            target = kit_root / "templates" / "shared" / "agents" / "git-start.md"
+            target.write_text("v2\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "temp change")
+            target.write_text("v1\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "revert temp change")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("re-bootstrap niepotrzebny", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -6,7 +6,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from guides.resolver import normalize_language, resolve_preset_path, resolve_profile
+from guides.resolver import (
+    normalize_auth_variant,
+    normalize_language,
+    resolve_preset_path,
+    resolve_profile,
+)
 
 KIT_ROOT = Path(__file__).resolve().parents[1]
 
@@ -172,6 +177,73 @@ class TestResolver(unittest.TestCase):
             self.assertNotIn("capability:files-storage", backend.module_ids)
             self.assertNotIn("capability:files-storage", backend.missing_modules)
             self.assertIn("capability:files", backend.content)
+
+    def test_normalize_auth_variant_default_custom(self) -> None:
+        """Brak/nierozpoznana wartość decisions.auth → default custom."""
+        self.assertEqual(normalize_auth_variant(None), "custom")
+        self.assertEqual(normalize_auth_variant("unknown"), "custom")
+        self.assertEqual(normalize_auth_variant("ALLAUTH"), "allauth")
+        self.assertEqual(normalize_auth_variant(" jwt "), "jwt")
+        self.assertEqual(normalize_auth_variant("custom"), "custom")
+
+    def test_normalize_auth_variant_non_string_does_not_crash(self) -> None:
+        """decisions.auth jako YAML bool/int (niecudzysłowione) nie crashuje, default custom."""
+        for raw in (True, False, 1, 0, ["allauth"], {"a": 1}):
+            with self.subTest(raw=raw):
+                self.assertEqual(normalize_auth_variant(raw), "custom")
+
+    def test_shop_profile_auth_variant_allauth(self) -> None:
+        """shop.yaml ma decisions.auth: allauth — wariant trafia do enabled i do bundle backend."""
+        resolved = resolve_profile(resolve_preset_path("shop", KIT_ROOT), kit_root=KIT_ROOT)
+        self.assertIn("capability:auth:allauth", resolved.enabled_module_ids)
+        self.assertIn("capability:auth:allauth", resolved.bundles["backend"].module_ids)
+        self.assertNotIn("capability:auth:jwt", resolved.enabled_module_ids)
+        self.assertNotIn("capability:auth:custom", resolved.enabled_module_ids)
+
+    def test_auth_variant_default_custom_without_decision(self) -> None:
+        """Profil z capability:auth ale bez decisions.auth → wariant custom (default)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            profile = Path(tmp) / "fork.yaml"
+            profile.write_text(
+                "\n".join(
+                    [
+                        "name: fork-auth-default",
+                        "extends: profiles/_base.yaml",
+                        "bundles:",
+                        "  backend:",
+                        "    - capability:auth",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            resolved = resolve_profile(profile, kit_root=KIT_ROOT)
+            self.assertIn("capability:auth:custom", resolved.bundles["backend"].module_ids)
+            self.assertNotIn("capability:auth:allauth", resolved.bundles["backend"].module_ids)
+
+    def test_codegen_graphql_swaps_api_contract(self) -> None:
+        """codegen: graphql podmienia arch:api-contract na arch:api-contract:graphql."""
+        resolved = resolve_profile(
+            resolve_preset_path("shop", KIT_ROOT),
+            kit_root=KIT_ROOT,
+            codegen_override="graphql",
+        )
+        self.assertEqual(resolved.codegen, "graphql")
+        self.assertIn("arch:api-contract:graphql", resolved.enabled_module_ids)
+        self.assertNotIn("arch:api-contract", resolved.enabled_module_ids)
+        self.assertIn("arch:api-contract:graphql", resolved.bundles["architecture"].module_ids)
+
+    def test_search_decision_flows_to_infra_bundle(self) -> None:
+        """decisions.search: postgres (shop.yaml) trafia do bundle infra jak inne sloty infra."""
+        resolved = resolve_profile(resolve_preset_path("shop", KIT_ROOT), kit_root=KIT_ROOT)
+        self.assertIn("infra:search:postgres", resolved.bundles["infra"].module_ids)
+
+    def test_taskfile_and_docker_structure_in_base_architecture(self) -> None:
+        """arch:taskfile i arch:docker-structure dziedziczone z _base przez każdy preset extends."""
+        resolved = resolve_profile(resolve_preset_path("shop", KIT_ROOT), kit_root=KIT_ROOT)
+        arch = resolved.bundles["architecture"]
+        self.assertIn("arch:taskfile", arch.module_ids)
+        self.assertIn("arch:docker-structure", arch.module_ids)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rozszerzenie resolvera profili o warianty wybierane deklaratywnie zamiast twardo zakodowanych, kilka nowych modułów wypełniających luki znalezione przy analizie architektury (porównanie z cookiecutter-django, Saleor, Medusa), poprawka workflow `/git-start`↔`/git-end`, mechanizm wykrywania rozjazdu kita względem bootstrapowanego projektu, i fix instalacji `BUGBOT.md` dla wszystkich klientów.

### `decisions.auth` — wybór wariantu backendu auth
- `allauth` / `jwt` / `custom` (**default** — brak enforced pakietu)
- resolver dokleja `capability:auth:{wariant}` zaraz po `capability:auth` w module_ids (flat i per-bundle)
- `profiles/shop.yaml` → `decisions.auth: allauth`

### `codegen: graphql` — trzecia wartość obok `orval`/`none`
- `arch:api-contract:graphql` (Strawberry/Graphene, N+1/DataLoader, Apollo/urql, graphql-codegen)
- CLI (`--codegen`, też w `bootstrap-project.sh`) i MCP tool `get_codegen()` spójne z resolverem

### `decisions.search` — Postgres tsvector (default) / Meilisearch
- reużywa istniejący mechanizm infra-slotów

### Nowe moduły
- `arch:taskfile`, `arch:docker-structure` — dziedziczone przez `profiles/_base.yaml`
- `pattern:webhooks` — checklist idempotency/podpis/retry

### `core:repo-first` — nowe reguły
- Decyzyjna tabela: fakt produktu vs reużywalna zasada kita
- Jedno wywołanie `check_kit_status` na start pracy, zapytaj o zgodę zanim re-bootstrap

### `/git-start` ↔ `/git-end` — powrót na branch sprzed startu
- `startedFrom` w git config, `/git-end` wraca po pushu jeśli zapisany

### `check_kit_status` — tanie wykrywanie rozjazdu kita
- `.ai/.kit-bootstrap.json` stamp + porównanie `git rev-parse`/`git diff --name-only` (bez czytania treści modułów)

### Fix: `BUGBOT.md` tylko dla `--clients cursor`
- Root `BUGBOT.md` teraz niezależny od `--clients` — `/review-bugbot` działał wcześniej "na sucho" (bez reguł repo) dla projektów bez Cursora

### Testy i review
- +13 testów jednostkowych, 35/35 zielone
- Naprawiony crash: `decisions.auth: true` (niecudzysłowiony YAML bool)
- Przeprowadzone: bugbot, edge-case, standards, spec review — wszystkie findings naprawione

## Test plan

- [x] `PYTHONPATH=src uv run pytest -q` — 35/35 zielone
- [x] Smoke test bootstrap `--clients claude` → root `BUGBOT.md` obecny, `.cursor/BUGBOT.md` poprawnie brak
- [x] `resolve_profile("shop")` ręcznie zweryfikowany: `capability:auth:allauth`, `pattern:webhooks`, `infra:search:postgres`, `arch:taskfile`/`arch:docker-structure` w odpowiednich bundlach

Closes #9