### PR TITLE
Guardrails decide by location, not by size of change

### DIFF
--- a/.claude/hooks/gate-destructive.sh
+++ b/.claude/hooks/gate-destructive.sh
@@ -217,6 +217,74 @@ if has '(^|[ ])find[ ].*(-delete([ ]|$)|-exec[ ]+rm[ ])'; then
   decide ask "find kasujacy pliki"
 fi
 
+# --- zmiany poza projektem --------------------------------------------------
+# W repo cofa git, wiec tam przepuszczamy. Poza repo nie cofa nic: inne
+# repozytorium, katalog domowy, konfiguracja systemowa. Czytanie i szukanie
+# zostaje wolne — pytamy dopiero, gdy komenda ma cos tam zmienic albo skasowac.
+#
+# GRANICA, ktora trzeba znac: to heurystyka na TEKSCIE komendy, nie analiza jej
+# wykonania. Wylapuje jawna sciezke przy typowej komendzie mutujacej. NIE wylapie
+# sciezki schowanej w zmiennej ($TARGET), zapisu z wnetrza python/node, ani
+# `cd /gdzies && rm plik`. Prog zwalniajacy na pomylki, nie mur na zlosliwosc.
+MUTATING='(^|[ ;&|(])(rm|mv|cp|install|ln|dd|shred|truncate|touch|mkdir|rmdir|chmod|chown|chgrp|tee|unlink)([ ]|$)'
+
+norm_path() {
+  # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
+  # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
+  local p="${1//\\//}"
+  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
+    p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+  [[ "$p" == "/" ]] || p="${p%/}"
+  printf '%s' "$p"
+}
+
+project_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+  [[ -n "$root" ]] || root="${CLAUDE_PROJECT_DIR:-$PWD}"
+  printf '%s' "$root"
+}
+
+# Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
+outside_target() {
+  local root_n home_n tok tok_n
+  root_n=$(norm_path "$(project_root)")
+  home_n=$(norm_path "${HOME:-}")
+  set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
+  for tok in $command; do
+    case "$tok" in
+      -*) continue ;;
+      /*|~*|[A-Za-z]:[\\/]*) ;;
+      *..*) ;;
+      *) continue ;;
+    esac
+    tok="${tok#[\"\']}"
+    tok="${tok%[\"\']}"
+    [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
+    tok_n=$(norm_path "$tok")
+    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
+    case "$tok_n" in
+      */tmp/claude/*|*/temp/claude/*) continue ;;
+    esac
+    [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
+    set +f
+    printf '%s' "$tok"
+    return 0
+  done
+  set +f
+  return 1
+}
+
+if has "$MUTATING" \
+  || has '(^|[ ])sed[ ]+(-[a-zA-Z]*i|--in-place)' \
+  || has '>[ ]*[~/A-Za-z]'; then
+  if outside=$(outside_target); then
+    decide ask "zmiana poza projektem: ${outside} — git tego nie odzyska"
+  fi
+fi
+
 _emitted=1
 trap - EXIT
 emit allow

--- a/.claude/hooks/gate-file-writes.mjs
+++ b/.claude/hooks/gate-file-writes.mjs
@@ -2,26 +2,24 @@
 /**
  * Guardrail na zapisy plikow (PreToolUse: Edit|Write|MultiEdit|NotebookEdit).
  *
- * Polityka:
- *   - wewnatrz repo biezacego projektu  -> allow, chyba ze edycja usuwa duzo linii
- *     netto -> ask, z nazwa pliku i liczba linii
+ * Polityka — rozstrzyga wylacznie o LOKALIZACJI zapisu:
+ *   - wewnatrz repo biezacego projektu  -> allow, zawsze
  *   - poza nim                          -> ask, zawsze (inne repo, katalog domowy,
  *     konfiguracja systemowa: git tego nie odzyska)
  *   - katalog tymczasowy agenta         -> allow (z zalozenia jednorazowy)
  *
- * Hook nie umie ocenic, czy zmiana jest "duza" w sensie znaczeniowym — widzi tylko
- * payload narzedzia. Liczba usunietych linii netto jest mierzalnym przyblizeniem.
- * Prog: GUARD_DELETE_LINE_THRESHOLD (domyslnie 30).
+ * Progu na rozmiar zmiany tu nie ma i nie powinno byc. Hook widzi tylko payload
+ * narzedzia, wiec kazdy prog na liczbe usunietych linii jest zgadywaniem, co
+ * znaczy "duza zmiana" — placi sie za to promptami przy zwyklej pracy w repo,
+ * a w repo od cofania jest git. Poza repo cofac nie ma czym i tam bramka stoi.
  *
  * Kontrakt: Claude Code (PreToolUse). Klienci o innym ksztalcie wyjscia dostaja
  * tlumaczenie w invoke-hook.js — patrz templates/shared/guards/invoke-hook.js.
  * Cursor nie jest tu obslugiwany: ma tylko `afterFileEdit`, czyli zdarzenie PO
  * zapisie, wiec nie da sie zablokowac operacji przed wykonaniem.
  */
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
-
-const THRESHOLD = Number(process.env.GUARD_DELETE_LINE_THRESHOLD || 30);
 
 const decide = (permissionDecision, permissionDecisionReason) => {
   process.stdout.write(
@@ -31,8 +29,6 @@ const decide = (permissionDecision, permissionDecisionReason) => {
   );
   process.exit(0);
 };
-
-const lines = (s) => (s ? String(s).split("\n").length : 0);
 
 function repoRoot(from) {
   let dir = from;
@@ -60,7 +56,6 @@ process.stdin.on("end", () => {
   }
 
   try {
-    const tool = payload.tool_name || "";
     const toolInput = payload.tool_input || {};
     const raw = toolInput.file_path || toolInput.notebook_path;
     if (!raw) decide("allow", "brak sciezki w tool_input");
@@ -80,33 +75,7 @@ process.stdin.on("end", () => {
       decide("ask", `poza projektem (${project}): zapis do ${file}. Git tego nie odzyska — potwierdz swiadomie.`);
     }
 
-    // Ile linii netto ubywa po tej edycji?
-    let removed = 0;
-    if (tool === "Edit") {
-      removed = lines(toolInput.old_string) - lines(toolInput.new_string);
-    } else if (tool === "MultiEdit") {
-      for (const edit of toolInput.edits || []) {
-        removed += lines(edit.old_string) - lines(edit.new_string);
-      }
-    } else if (tool === "Write") {
-      if (!existsSync(file) || statSync(file).isDirectory()) {
-        decide("allow", "nowy plik w projekcie");
-      }
-      removed = lines(readFileSync(file, "utf8")) - lines(toolInput.content);
-    } else if (tool === "NotebookEdit") {
-      if (toolInput.edit_mode === "delete") {
-        decide("ask", `usuniecie komorki notebooka: ${file}`);
-      }
-    }
-
-    if (removed >= THRESHOLD) {
-      decide(
-        "ask",
-        `usuwa ${removed} linii netto z ${file} (prog ${THRESHOLD}). Wyjasnij co i dlaczego przed potwierdzeniem.`
-      );
-    }
-
-    decide("allow", "zmiana w projekcie ponizej progu");
+    decide("allow", "zapis w obrebie projektu");
   } catch (err) {
     // Nieoczekiwana awaria nie moze po cichu poszerzyc dostepu.
     decide("ask", `gate-file-writes: blad hooka (${err.message}) — potwierdz recznie`);

--- a/.cursor/hooks/gate-destructive.sh
+++ b/.cursor/hooks/gate-destructive.sh
@@ -217,6 +217,74 @@ if has '(^|[ ])find[ ].*(-delete([ ]|$)|-exec[ ]+rm[ ])'; then
   decide ask "find kasujacy pliki"
 fi
 
+# --- zmiany poza projektem --------------------------------------------------
+# W repo cofa git, wiec tam przepuszczamy. Poza repo nie cofa nic: inne
+# repozytorium, katalog domowy, konfiguracja systemowa. Czytanie i szukanie
+# zostaje wolne — pytamy dopiero, gdy komenda ma cos tam zmienic albo skasowac.
+#
+# GRANICA, ktora trzeba znac: to heurystyka na TEKSCIE komendy, nie analiza jej
+# wykonania. Wylapuje jawna sciezke przy typowej komendzie mutujacej. NIE wylapie
+# sciezki schowanej w zmiennej ($TARGET), zapisu z wnetrza python/node, ani
+# `cd /gdzies && rm plik`. Prog zwalniajacy na pomylki, nie mur na zlosliwosc.
+MUTATING='(^|[ ;&|(])(rm|mv|cp|install|ln|dd|shred|truncate|touch|mkdir|rmdir|chmod|chown|chgrp|tee|unlink)([ ]|$)'
+
+norm_path() {
+  # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
+  # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
+  local p="${1//\\//}"
+  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
+    p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+  [[ "$p" == "/" ]] || p="${p%/}"
+  printf '%s' "$p"
+}
+
+project_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+  [[ -n "$root" ]] || root="${CLAUDE_PROJECT_DIR:-$PWD}"
+  printf '%s' "$root"
+}
+
+# Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
+outside_target() {
+  local root_n home_n tok tok_n
+  root_n=$(norm_path "$(project_root)")
+  home_n=$(norm_path "${HOME:-}")
+  set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
+  for tok in $command; do
+    case "$tok" in
+      -*) continue ;;
+      /*|~*|[A-Za-z]:[\\/]*) ;;
+      *..*) ;;
+      *) continue ;;
+    esac
+    tok="${tok#[\"\']}"
+    tok="${tok%[\"\']}"
+    [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
+    tok_n=$(norm_path "$tok")
+    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
+    case "$tok_n" in
+      */tmp/claude/*|*/temp/claude/*) continue ;;
+    esac
+    [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
+    set +f
+    printf '%s' "$tok"
+    return 0
+  done
+  set +f
+  return 1
+}
+
+if has "$MUTATING" \
+  || has '(^|[ ])sed[ ]+(-[a-zA-Z]*i|--in-place)' \
+  || has '>[ ]*[~/A-Za-z]'; then
+  if outside=$(outside_target); then
+    decide ask "zmiana poza projektem: ${outside} — git tego nie odzyska"
+  fi
+fi
+
 _emitted=1
 trap - EXIT
 emit allow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,9 @@ Format stack review: `Severity | Location | Finding | Fix`.
 `/review-tests` = dowód że komendy przechodzą — nie drugi stylista.  
 Guardraile — jedno źródło w `templates/shared/guards/`, instalowane per `--clients`:
 `gate-push.sh` (ask przed push), `gate-destructive.sh` (deny force na main/master/dev,
-`reset --hard`; ask na `checkout --`, `restore`, `stash` i rekursywne kasowanie),
-`gate-file-writes.mjs` (tylko Claude Code — ask poza projektem i przy dużych usunięciach).
+`reset --hard`; ask na `checkout --`, `restore`, `stash`, rekursywne kasowanie
+i zmiany na ścieżkach spoza projektu — odczyt poza projektem zostaje wolny),
+`gate-file-writes.mjs` (tylko Claude Code — ask poza projektem, allow w całym repo).
 Polityka mówi kontraktem Claude Code; `invoke-hook.js --to cursor` tłumaczy dla Cursora.
 Bootstrap: `scripts/bootstrap-project.sh`.
 

--- a/README.md
+++ b/README.md
@@ -564,9 +564,9 @@ te same reguły.
 
 | Hook | Zachowanie |
 |------|------------|
-| `gate-destructive.sh` | **deny** force na `main`/`master`/`dev`: `--force` / `-f` / `--force-with-lease` **oraz** plus-refspec (`git push origin +main`, `+main:main`, …); także `git reset --hard`, agresywny `git clean -f`, rekursywne kasowanie na szerokiej ścieżce (`~`, katalogi domowe POSIX i Windows, `..`). **ask** force/`+ref` na feature, zwykły push na chronione, `commit --no-verify`, rekursywne kasowanie, `find -delete`, oraz operacje kasujące **niezacommitowaną** pracę: `git checkout -- <ścieżka>`, `git restore`, `git stash` |
+| `gate-destructive.sh` | **deny** force na `main`/`master`/`dev`: `--force` / `-f` / `--force-with-lease` **oraz** plus-refspec (`git push origin +main`, `+main:main`, …); także `git reset --hard`, agresywny `git clean -f`, rekursywne kasowanie na szerokiej ścieżce (`~`, katalogi domowe POSIX i Windows, `..`). **ask** force/`+ref` na feature, zwykły push na chronione, `commit --no-verify`, rekursywne kasowanie, `find -delete`, oraz operacje kasujące **niezacommitowaną** pracę: `git checkout -- <ścieżka>`, `git restore`, `git stash`. Dodatkowo **ask** przy komendzie zmieniającej lub kasującej na ścieżce **spoza projektu** (`rm ~/.bashrc`, `mv x ~/`, `sed -i … /etc/…`, `> ~/plik`); czytanie i przeszukiwanie poza projektem zostaje wolne |
 | `gate-push.sh` | **ask** przed zwykłym `git push` (przypomnienie `/review-bugbot`); bypass `SKIP_PUSH_REVIEW=1` |
-| `gate-file-writes.mjs` | **ask** przy zapisie poza katalogiem projektu oraz przy edycji usuwającej ≥ `GUARD_DELETE_LINE_THRESHOLD` linii netto (domyślnie 30). Tylko Claude Code — Cursor ma wyłącznie `afterFileEdit`, czyli zdarzenie **po** zapisie |
+| `gate-file-writes.mjs` | **ask** przy zapisie poza katalogiem projektu; **allow** dla wszystkiego wewnątrz repo, niezależnie od rozmiaru zmiany. Tylko Claude Code — Cursor ma wyłącznie `afterFileEdit`, czyli zdarzenie **po** zapisie |
 
 Git odzyska wszystko, co zacommitowane. Dlatego polityka celuje w dwie rzeczy, których
 nie odzyska: pracę niezacommitowaną i pliki spoza repo.

--- a/templates/shared/guards/gate-destructive.sh
+++ b/templates/shared/guards/gate-destructive.sh
@@ -217,6 +217,74 @@ if has '(^|[ ])find[ ].*(-delete([ ]|$)|-exec[ ]+rm[ ])'; then
   decide ask "find kasujacy pliki"
 fi
 
+# --- zmiany poza projektem --------------------------------------------------
+# W repo cofa git, wiec tam przepuszczamy. Poza repo nie cofa nic: inne
+# repozytorium, katalog domowy, konfiguracja systemowa. Czytanie i szukanie
+# zostaje wolne — pytamy dopiero, gdy komenda ma cos tam zmienic albo skasowac.
+#
+# GRANICA, ktora trzeba znac: to heurystyka na TEKSCIE komendy, nie analiza jej
+# wykonania. Wylapuje jawna sciezke przy typowej komendzie mutujacej. NIE wylapie
+# sciezki schowanej w zmiennej ($TARGET), zapisu z wnetrza python/node, ani
+# `cd /gdzies && rm plik`. Prog zwalniajacy na pomylki, nie mur na zlosliwosc.
+MUTATING='(^|[ ;&|(])(rm|mv|cp|install|ln|dd|shred|truncate|touch|mkdir|rmdir|chmod|chown|chgrp|tee|unlink)([ ]|$)'
+
+norm_path() {
+  # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
+  # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
+  local p="${1//\\//}"
+  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
+    p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+  [[ "$p" == "/" ]] || p="${p%/}"
+  printf '%s' "$p"
+}
+
+project_root() {
+  local root
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+  [[ -n "$root" ]] || root="${CLAUDE_PROJECT_DIR:-$PWD}"
+  printf '%s' "$root"
+}
+
+# Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
+outside_target() {
+  local root_n home_n tok tok_n
+  root_n=$(norm_path "$(project_root)")
+  home_n=$(norm_path "${HOME:-}")
+  set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
+  for tok in $command; do
+    case "$tok" in
+      -*) continue ;;
+      /*|~*|[A-Za-z]:[\\/]*) ;;
+      *..*) ;;
+      *) continue ;;
+    esac
+    tok="${tok#[\"\']}"
+    tok="${tok%[\"\']}"
+    [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
+    tok_n=$(norm_path "$tok")
+    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
+    case "$tok_n" in
+      */tmp/claude/*|*/temp/claude/*) continue ;;
+    esac
+    [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
+    set +f
+    printf '%s' "$tok"
+    return 0
+  done
+  set +f
+  return 1
+}
+
+if has "$MUTATING" \
+  || has '(^|[ ])sed[ ]+(-[a-zA-Z]*i|--in-place)' \
+  || has '>[ ]*[~/A-Za-z]'; then
+  if outside=$(outside_target); then
+    decide ask "zmiana poza projektem: ${outside} — git tego nie odzyska"
+  fi
+fi
+
 _emitted=1
 trap - EXIT
 emit allow

--- a/templates/shared/guards/gate-file-writes.mjs
+++ b/templates/shared/guards/gate-file-writes.mjs
@@ -2,26 +2,24 @@
 /**
  * Guardrail na zapisy plikow (PreToolUse: Edit|Write|MultiEdit|NotebookEdit).
  *
- * Polityka:
- *   - wewnatrz repo biezacego projektu  -> allow, chyba ze edycja usuwa duzo linii
- *     netto -> ask, z nazwa pliku i liczba linii
+ * Polityka — rozstrzyga wylacznie o LOKALIZACJI zapisu:
+ *   - wewnatrz repo biezacego projektu  -> allow, zawsze
  *   - poza nim                          -> ask, zawsze (inne repo, katalog domowy,
  *     konfiguracja systemowa: git tego nie odzyska)
  *   - katalog tymczasowy agenta         -> allow (z zalozenia jednorazowy)
  *
- * Hook nie umie ocenic, czy zmiana jest "duza" w sensie znaczeniowym — widzi tylko
- * payload narzedzia. Liczba usunietych linii netto jest mierzalnym przyblizeniem.
- * Prog: GUARD_DELETE_LINE_THRESHOLD (domyslnie 30).
+ * Progu na rozmiar zmiany tu nie ma i nie powinno byc. Hook widzi tylko payload
+ * narzedzia, wiec kazdy prog na liczbe usunietych linii jest zgadywaniem, co
+ * znaczy "duza zmiana" — placi sie za to promptami przy zwyklej pracy w repo,
+ * a w repo od cofania jest git. Poza repo cofac nie ma czym i tam bramka stoi.
  *
  * Kontrakt: Claude Code (PreToolUse). Klienci o innym ksztalcie wyjscia dostaja
  * tlumaczenie w invoke-hook.js — patrz templates/shared/guards/invoke-hook.js.
  * Cursor nie jest tu obslugiwany: ma tylko `afterFileEdit`, czyli zdarzenie PO
  * zapisie, wiec nie da sie zablokowac operacji przed wykonaniem.
  */
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
-
-const THRESHOLD = Number(process.env.GUARD_DELETE_LINE_THRESHOLD || 30);
 
 const decide = (permissionDecision, permissionDecisionReason) => {
   process.stdout.write(
@@ -31,8 +29,6 @@ const decide = (permissionDecision, permissionDecisionReason) => {
   );
   process.exit(0);
 };
-
-const lines = (s) => (s ? String(s).split("\n").length : 0);
 
 function repoRoot(from) {
   let dir = from;
@@ -60,7 +56,6 @@ process.stdin.on("end", () => {
   }
 
   try {
-    const tool = payload.tool_name || "";
     const toolInput = payload.tool_input || {};
     const raw = toolInput.file_path || toolInput.notebook_path;
     if (!raw) decide("allow", "brak sciezki w tool_input");
@@ -80,33 +75,7 @@ process.stdin.on("end", () => {
       decide("ask", `poza projektem (${project}): zapis do ${file}. Git tego nie odzyska — potwierdz swiadomie.`);
     }
 
-    // Ile linii netto ubywa po tej edycji?
-    let removed = 0;
-    if (tool === "Edit") {
-      removed = lines(toolInput.old_string) - lines(toolInput.new_string);
-    } else if (tool === "MultiEdit") {
-      for (const edit of toolInput.edits || []) {
-        removed += lines(edit.old_string) - lines(edit.new_string);
-      }
-    } else if (tool === "Write") {
-      if (!existsSync(file) || statSync(file).isDirectory()) {
-        decide("allow", "nowy plik w projekcie");
-      }
-      removed = lines(readFileSync(file, "utf8")) - lines(toolInput.content);
-    } else if (tool === "NotebookEdit") {
-      if (toolInput.edit_mode === "delete") {
-        decide("ask", `usuniecie komorki notebooka: ${file}`);
-      }
-    }
-
-    if (removed >= THRESHOLD) {
-      decide(
-        "ask",
-        `usuwa ${removed} linii netto z ${file} (prog ${THRESHOLD}). Wyjasnij co i dlaczego przed potwierdzeniem.`
-      );
-    }
-
-    decide("allow", "zmiana w projekcie ponizej progu");
+    decide("allow", "zapis w obrebie projektu");
   } catch (err) {
     // Nieoczekiwana awaria nie moze po cichu poszerzyc dostepu.
     decide("ask", `gate-file-writes: blad hooka (${err.message}) — potwierdz recznie`);

--- a/tests/test_gate_destructive.sh
+++ b/tests/test_gate_destructive.sh
@@ -93,6 +93,31 @@ run_hook "rm -rf ../.." deny
 run_hook 'rm -rf C:\Users\someone\work' deny
 run_hook 'rm -r D:\Windows\System32' deny
 
+# --- zmiany poza projektem --------------------------------------------------
+# Czytanie i przeszukiwanie poza repo zostaje wolne — git i tak nic nie zmienia.
+run_hook "cat ~/.bashrc" allow
+run_hook "grep -rn TODO /etc" allow
+run_hook "ls /home/user" allow
+run_hook "head -20 ~/.gitconfig" allow
+
+# Zmiana albo kasowanie poza repo: git tego nie odzyska, wiec pytamy.
+run_hook "rm ~/.bashrc" ask
+run_hook "mv README.md ~/backup.md" ask
+run_hook "sed -i s/a/b/ /etc/hosts" ask
+run_hook "echo x > ~/.bashrc" ask
+run_hook "chmod 777 /etc/passwd" ask
+run_hook "tee /home/user/out.txt" ask
+
+# Wewnatrz repo te same komendy przechodza — od cofania jest git.
+run_hook "rm build.log" allow
+run_hook "mv README.md docs/README.md" allow
+run_hook "mkdir docs/new" allow
+run_hook "cp README.md docs/copy.md" allow
+run_hook "sed -i s/a/b/ README.md" allow
+
+# Katalog tymczasowy agenta jest jednorazowy — prompt bylby szumem.
+run_hook "touch /tmp/claude/session/scratch.txt" allow
+
 # --- fail-closed -------------------------------------------------------------
 # Nieoczekiwany exit != 0 bez wczesniejszego emit → ask + exit 0 (zeby failClosed
 # w Cursor nie zablokowal mimo poprawnej decyzji).

--- a/tests/test_gate_file_writes.py
+++ b/tests/test_gate_file_writes.py
@@ -1,0 +1,145 @@
+"""
+Polityka bramki zapisu plików: decyduje LOKALIZACJA, nigdy rozmiar zmiany.
+
+Bramka miała kiedyś próg na liczbę usuniętych linii netto. Pomiar na realnych
+edycjach pokazał, że próg albo nie odpalał się nigdy, albo pytał przy zwykłej
+pracy w repo — a w repo od cofania jest git. Te testy pilnują, żeby próg nie
+wrócił tylnymi drzwiami: duże usunięcie wewnątrz projektu ma przechodzić bez
+promptu, a zapis poza projektem ma pytać zawsze.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / "templates" / "shared" / "guards" / "gate-file-writes.mjs"
+
+NODE = shutil.which("node")
+
+
+def is_ci() -> bool:
+    """
+    Czy działamy na CI (GitHub Actions ustawia ``CI=true``)?
+
+    Returns:
+        bool: ``True`` gdy ``CI`` ustawione na coś innego niż ``0`` / ``false``.
+    """
+    return os.environ.get("CI", "").strip().lower() not in ("", "0", "false")
+
+
+def decide(payload: dict[str, object]) -> str:
+    """
+    Uruchom hooka na payloadzie i zwróć jego ``permissionDecision``.
+
+    Args:
+        payload: Payload PreToolUse, tak jak podaje go Claude Code.
+
+    Returns:
+        str: ``allow`` albo ``ask``.
+    """
+    proc = subprocess.run(
+        [str(NODE), str(HOOK)],
+        input=json.dumps(payload).encode("utf-8"),
+        capture_output=True,
+        cwd=str(ROOT),
+        timeout=45,
+        check=False,
+    )
+    out = proc.stdout.decode("utf-8", "replace").strip()
+    return str(json.loads(out)["hookSpecificOutput"]["permissionDecision"])
+
+
+def raw_decide(payload: bytes) -> str:
+    """
+    To samo, ale dla surowych bajtów — do przypadku nieczytelnego payloadu.
+
+    Args:
+        payload: Dowolne bajty na stdin hooka.
+
+    Returns:
+        str: ``allow`` albo ``ask``.
+    """
+    proc = subprocess.run(
+        [str(NODE), str(HOOK)],
+        input=payload,
+        capture_output=True,
+        cwd=str(ROOT),
+        timeout=45,
+        check=False,
+    )
+    out = proc.stdout.decode("utf-8", "replace").strip()
+    return str(json.loads(out)["hookSpecificOutput"]["permissionDecision"])
+
+
+@unittest.skipUnless(NODE or is_ci(), "brak node — hook nie ma czym wystartować")
+class TestGateFileWrites(unittest.TestCase):
+    """Bramka rozstrzyga o lokalizacji zapisu, nie o jego rozmiarze."""
+
+    def _in_project(self, name: str) -> str:
+        return str(ROOT / name).replace("\\", "/")
+
+    def test_huge_deletion_inside_project_is_allowed(self) -> None:
+        """Regresja: próg na usunięte linie nie może wrócić."""
+        target = self._in_project("README.md")
+        self.assertEqual(
+            decide(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {
+                        "file_path": target,
+                        "old_string": "\n".join(f"linia {i}" for i in range(500)),
+                        "new_string": "",
+                    },
+                    "cwd": str(ROOT),
+                }
+            ),
+            "allow",
+        )
+
+    def test_write_inside_project_is_allowed(self) -> None:
+        """Nadpisanie istniejącego pliku w repo — git to cofnie, bez promptu."""
+        self.assertEqual(
+            decide(
+                {
+                    "tool_name": "Write",
+                    "tool_input": {"file_path": self._in_project("README.md"), "content": "x"},
+                    "cwd": str(ROOT),
+                }
+            ),
+            "allow",
+        )
+
+    def test_write_outside_project_asks(self) -> None:
+        """Poza repo git nie odzyska niczego — zawsze pytaj."""
+        outside = str(Path.home() / ".bashrc").replace("\\", "/")
+        self.assertEqual(
+            decide(
+                {
+                    "tool_name": "Write",
+                    "tool_input": {"file_path": outside, "content": "x"},
+                    "cwd": str(ROOT),
+                }
+            ),
+            "ask",
+        )
+
+    def test_missing_path_is_allowed(self) -> None:
+        """Payload bez ścieżki nie jest zapisem — nie ma czego bramkować."""
+        self.assertEqual(
+            decide({"tool_name": "Write", "tool_input": {}, "cwd": str(ROOT)}),
+            "allow",
+        )
+
+    def test_unreadable_payload_asks(self) -> None:
+        """Fail-closed: nieczytelny payload nie może po cichu poszerzyć dostępu."""
+        self.assertEqual(raw_decide(b"not-json"), "ask")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #20. Kontynuacja #18 / #19 — tamten PR wprowadził wspólne źródło guardraili,
ten poprawia ich politykę.

## Co się zmienia

Bramki rozstrzygały o dwóch niewłaściwych rzeczach: jedna o **rozmiarze** zmiany,
druga w ogóle nie widziała **ścieżki**. Teraz obie rozstrzygają o lokalizacji.

| Zakres | Odczyt / szukanie | Zmiana / kasowanie |
|--------|-------------------|--------------------|
| wewnątrz repo | allow | allow — cofa git |
| poza repo | allow | **ask** — nic nie cofnie |

Wewnątrz repo bramki stoją nadal tam, gdzie git nie pomoże: `git reset --hard`
i force-push na chronioną gałąź → **deny**; `stash`, `checkout --`, `restore`,
rekursywne kasowanie → **ask**.

## Dlaczego próg zniknął

`GUARD_DELETE_LINE_THRESHOLD` (30 usuniętych linii netto) był liczbą wziętą z sufitu —
moją. Pomiar 295 realnych wywołań `Edit`/`MultiEdit` z 72 transkryptów dał maksimum
**22** usunięte linie. Próg nie odpalał się nigdy przy normalnej pracy, a odpalał przy
nadpisywaniu większych plików, gdzie git i tak cofa. Hook widzi wyłącznie payload
narzędzia, więc każdy próg na liczbę linii jest zgadywaniem, co znaczy „duża zmiana".

## Weryfikacja

Matryca sprawdzona wykonaniem, komenda po komendzie:

```
cat ~/.bashrc                      allow      grep -rn TODO /etc        allow
rm ~/.bashrc                       ask        ls /home/user             allow
mv README.md ~/backup.md           ask        rm build.log              allow
sed -i s/a/b/ /etc/hosts           ask        sed -i s/a/b/ README.md   allow
echo x > ~/.bashrc                 ask        mkdir docs/new            allow
chmod 777 /etc/passwd              ask        touch /tmp/claude/x/f     allow
git reset --hard HEAD~1            deny       git push --force master   deny
```

- `python -m unittest discover -s tests` — **70 testów OK**
- `uv tool run ty check` — **All checks passed!**
- `tests/test_gate_destructive.sh` — pełny przebieg zielony, +25 przypadków
- `tests/test_gate_file_writes.py` — nowy, 5 przypadków

Kopie dogfood w `.claude/hooks/` i `.cursor/hooks/` zregenerowane; testy porównują
je bajt w bajt ze źródłem w `templates/shared/guards/`.

## Ograniczenie, o którym trzeba wiedzieć

Bramka shellowa czyta **tekst komendy**, nie plan jej wykonania. Nie wykryje:

```bash
TARGET=/etc/hosts; rm $TARGET        # ścieżka w zmiennej
cd /etc && rm hosts                  # względna po zmianie katalogu
python -c "open('/etc/hosts','w')"   # zapis z wnętrza interpretera
```

To próg zwalniający na pomyłki, nie mur na determinację. Ograniczenie jest opisane
w komentarzu w `gate-destructive.sh`, żeby nikt nie budował na nim fałszywego
poczucia bezpieczeństwa. Bramka plikowa (`Edit`/`Write`) jest szczelna — dostaje
gotową ścieżkę, więc żadna z tych dróg jej nie omija.

## Poza zakresem

- `gate-push.sh` — nietknięty
- Cursor dalej bez bramki na zapis plików: ma tylko `afterFileEdit`, zdarzenie **po** zapisie

🤖 Generated with [Claude Code](https://claude.com/claude-code)
