### PR TITLE
fix: match paths case-insensitively on Windows in write gate

### DIFF
--- a/.claude/hooks/gate-file-writes.mjs
+++ b/.claude/hooks/gate-file-writes.mjs
@@ -40,9 +40,17 @@ function repoRoot(from) {
   }
 }
 
+// Windows nie rozroznia wielkosci liter w sciezkach: "m:\repo" i "M:\repo" to
+// ten sam katalog, a klient potrafi podac raz tak, raz tak. Porownanie bajt po
+// bajcie robilo z zapisu we wlasnym repo "zapis poza projektem" i pytalo przy
+// kazdej edycji. Tylko win32 — na POSIX /Home/x naprawde nie jest /home/x,
+// a case-insensitivity macOS zalezy od wolumenu, wiec zakladac jej nie wolno.
+const caseFold = (p) => (process.platform === "win32" ? p.toLowerCase() : p);
+
 const under = (file, root) => {
-  const r = resolve(root);
-  return file === r || file.startsWith(r + sep);
+  const f = caseFold(file);
+  const r = caseFold(resolve(root));
+  return f === r || f.startsWith(r + sep);
 };
 
 let input = "";

--- a/templates/shared/guards/gate-file-writes.mjs
+++ b/templates/shared/guards/gate-file-writes.mjs
@@ -40,9 +40,17 @@ function repoRoot(from) {
   }
 }
 
+// Windows nie rozroznia wielkosci liter w sciezkach: "m:\repo" i "M:\repo" to
+// ten sam katalog, a klient potrafi podac raz tak, raz tak. Porownanie bajt po
+// bajcie robilo z zapisu we wlasnym repo "zapis poza projektem" i pytalo przy
+// kazdej edycji. Tylko win32 — na POSIX /Home/x naprawde nie jest /home/x,
+// a case-insensitivity macOS zalezy od wolumenu, wiec zakladac jej nie wolno.
+const caseFold = (p) => (process.platform === "win32" ? p.toLowerCase() : p);
+
 const under = (file, root) => {
-  const r = resolve(root);
-  return file === r || file.startsWith(r + sep);
+  const f = caseFold(file);
+  const r = caseFold(resolve(root));
+  return f === r || f.startsWith(r + sep);
 };
 
 let input = "";

--- a/tests/test_gate_file_writes.py
+++ b/tests/test_gate_file_writes.py
@@ -129,6 +129,48 @@ class TestGateFileWrites(unittest.TestCase):
             "ask",
         )
 
+    @unittest.skipUnless(os.name == "nt", "litery dysku istnieją tylko na Windows")
+    def test_drive_letter_case_inside_project_is_allowed(self) -> None:
+        """
+        Windows nie rozróżnia wielkości liter w ścieżkach — bramka też nie może.
+
+        Klient potrafi podać ``m:/projects/...`` tam, gdzie ``cwd`` ma ``M:``.
+        To ten sam plik w tym samym repo; porównanie bajt po bajcie robiło
+        z niego zapis „poza projektem" i pytało przy każdej edycji.
+        """
+        target = self._in_project("README.md")
+        drive, rest = target[0], target[1:]
+        flipped = (drive.lower() if drive.isupper() else drive.upper()) + rest
+        self.assertNotEqual(flipped, target)
+        self.assertEqual(
+            decide(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"file_path": flipped, "old_string": "a", "new_string": "b"},
+                    "cwd": str(ROOT),
+                }
+            ),
+            "allow",
+        )
+
+    @unittest.skipUnless(os.name != "nt", "POSIX rozróżnia wielkość liter w ścieżkach")
+    def test_case_differing_path_outside_project_asks_on_posix(self) -> None:
+        """
+        Na POSIX ``/Home/x`` to nie ``/home/x`` — złagodzenie porównania nie
+        może przeciekać poza Windows.
+        """
+        outside = "/" + str(ROOT).lstrip("/").upper() + "/README.md"
+        self.assertEqual(
+            decide(
+                {
+                    "tool_name": "Write",
+                    "tool_input": {"file_path": outside, "content": "x"},
+                    "cwd": str(ROOT),
+                }
+            ),
+            "ask",
+        )
+
     def test_missing_path_is_allowed(self) -> None:
         """Payload bez ścieżki nie jest zapisem — nie ma czego bramkować."""
         self.assertEqual(


### PR DESCRIPTION
## Objaw

Bramka zapisu pytała o zgodę przy edycji pliku wewnątrz własnego repo, mimo
`defaultMode: acceptEdits`. Decyzja hooka przebija tryb uprawnień.

```
file_path m:/projects/kit/README.md  cwd M:/projects/kit -> ask
file_path M:/projects/kit/README.md  cwd M:/projects/kit -> allow
```

Ten sam plik, różna decyzja — zależnie od tego, jaką wielkość litery dysku
poda klient.

## Przyczyna

`under()` porównywało ścieżki bajt po bajcie (`startsWith`). Windows nie
rozróżnia wielkości liter w ścieżkach.

## Naprawa

`caseFold()` przed porównaniem, wyłącznie dla `win32`. Na POSIX `/Home/x`
naprawdę nie jest `/home/x`, a case-insensitivity macOS zależy od wolumenu,
więc złagodzenie nie może tam przeciekać.

## Dowód

```
tests/test_gate_file_writes.py  ->  7 tests, OK (1 skip: wariant POSIX-only)
uv tool run ty check            ->  All checks passed!
```

Ręcznie, oba warianty litery dysku:

```
m:/... -> allow "zapis w obrebie projektu"
M:/... -> allow "zapis w obrebie projektu"
C:/Users/.../.bashrc -> ask "poza projektem"
```

Nowy test skipuje się poza Windows i ma parę na POSIX pilnującą, że
porównanie tam pozostaje wrażliwe na wielkość liter.

## Poza zakresem

Ścieżki UNC (`\server\share`) — bramka dalej ich nie rozpoznaje jako
wewnątrz projektu. Osobna sprawa.

Closes #22
