### PR TITLE
perf: match guard patterns without spawning processes

### DIFF
--- a/.claude/hooks/gate-destructive.sh
+++ b/.claude/hooks/gate-destructive.sh
@@ -87,13 +87,34 @@ if [[ -z "${command}" ]]; then
   exit 0
 fi
 
-normalized=$(printf '%s' "$command" | tr '\n\r\t' '   ')
-# shellcheck disable=SC2001
-normalized=$(printf '%s' "$normalized" | sed 's/  */ /g')
+# Normalizacja bialych znakow bez `tr`/`sed` — te dwa potoki to cztery procesy
+# na kazde wywolanie bramki, czyli ~0,17 s na Windows. Podstawienia parametrow
+# robia to samo bez tworzenia procesu.
+normalized=${command//[$'\n\r\t']/ }
+while [[ "$normalized" == *"  "* ]]; do
+  normalized=${normalized//  / }
+done
 
+# Dopasowanie robi wbudowane [[ =~ ]], nie `printf | grep`.
+#
+# Kazde sprawdzenie wzorca kosztowalo dwa procesy, a polityka robi ich 33 —
+# na Windows tworzenie procesu to ~0,12 s, wiec jedno wywolanie bramki zajmowalo
+# ~2,5 s i suita regresji chodzila 158 s zamiast kilku. Wbudowane dopasowanie
+# nie tworzy procesu wcale.
+#
+# Wzorce to ERE po obu stronach (grep -E i regcomp), wiec skladnia zostaje bez
+# zmian. `nocasematch` zastepuje flage -i i jest wlaczany TYLKO na czas
+# dopasowania — globalnie zmienialby tez `case` nizej (m.in. */tmp/claude/*),
+# czyli poszerzalby polityke przy okazji optymalizacji.
+#
+# Wzorzec MUSI byc nieocytowany: w cudzyslowie [[ =~ ]] traktuje go jak zwykly
+# tekst i bramka przestaje lapac cokolwiek — po cichu, bez bledu.
 has() {
-  printf '%s' "$normalized" | grep -Eqi -- "$1" && return 0
-  return 1
+  local rc
+  shopt -s nocasematch
+  [[ "$normalized" =~ $1 ]] && rc=0 || rc=1
+  shopt -u nocasematch
+  return "$rc"
 }
 
 # True if push targets protected branch ref (main|master|dev), not remote named "dev".
@@ -232,7 +253,7 @@ norm_path() {
   # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
   # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
   local p="${1//\\//}"
-  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  p=${p,,}   # wbudowane male litery zamiast `printf | tr` — bez procesu
   if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
     p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
   fi

--- a/.cursor/hooks/gate-destructive.sh
+++ b/.cursor/hooks/gate-destructive.sh
@@ -87,13 +87,34 @@ if [[ -z "${command}" ]]; then
   exit 0
 fi
 
-normalized=$(printf '%s' "$command" | tr '\n\r\t' '   ')
-# shellcheck disable=SC2001
-normalized=$(printf '%s' "$normalized" | sed 's/  */ /g')
+# Normalizacja bialych znakow bez `tr`/`sed` — te dwa potoki to cztery procesy
+# na kazde wywolanie bramki, czyli ~0,17 s na Windows. Podstawienia parametrow
+# robia to samo bez tworzenia procesu.
+normalized=${command//[$'\n\r\t']/ }
+while [[ "$normalized" == *"  "* ]]; do
+  normalized=${normalized//  / }
+done
 
+# Dopasowanie robi wbudowane [[ =~ ]], nie `printf | grep`.
+#
+# Kazde sprawdzenie wzorca kosztowalo dwa procesy, a polityka robi ich 33 —
+# na Windows tworzenie procesu to ~0,12 s, wiec jedno wywolanie bramki zajmowalo
+# ~2,5 s i suita regresji chodzila 158 s zamiast kilku. Wbudowane dopasowanie
+# nie tworzy procesu wcale.
+#
+# Wzorce to ERE po obu stronach (grep -E i regcomp), wiec skladnia zostaje bez
+# zmian. `nocasematch` zastepuje flage -i i jest wlaczany TYLKO na czas
+# dopasowania — globalnie zmienialby tez `case` nizej (m.in. */tmp/claude/*),
+# czyli poszerzalby polityke przy okazji optymalizacji.
+#
+# Wzorzec MUSI byc nieocytowany: w cudzyslowie [[ =~ ]] traktuje go jak zwykly
+# tekst i bramka przestaje lapac cokolwiek — po cichu, bez bledu.
 has() {
-  printf '%s' "$normalized" | grep -Eqi -- "$1" && return 0
-  return 1
+  local rc
+  shopt -s nocasematch
+  [[ "$normalized" =~ $1 ]] && rc=0 || rc=1
+  shopt -u nocasematch
+  return "$rc"
 }
 
 # True if push targets protected branch ref (main|master|dev), not remote named "dev".
@@ -232,7 +253,7 @@ norm_path() {
   # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
   # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
   local p="${1//\\//}"
-  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  p=${p,,}   # wbudowane male litery zamiast `printf | tr` — bez procesu
   if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
     p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
   fi

--- a/templates/shared/guards/gate-destructive.sh
+++ b/templates/shared/guards/gate-destructive.sh
@@ -87,13 +87,34 @@ if [[ -z "${command}" ]]; then
   exit 0
 fi
 
-normalized=$(printf '%s' "$command" | tr '\n\r\t' '   ')
-# shellcheck disable=SC2001
-normalized=$(printf '%s' "$normalized" | sed 's/  */ /g')
+# Normalizacja bialych znakow bez `tr`/`sed` — te dwa potoki to cztery procesy
+# na kazde wywolanie bramki, czyli ~0,17 s na Windows. Podstawienia parametrow
+# robia to samo bez tworzenia procesu.
+normalized=${command//[$'\n\r\t']/ }
+while [[ "$normalized" == *"  "* ]]; do
+  normalized=${normalized//  / }
+done
 
+# Dopasowanie robi wbudowane [[ =~ ]], nie `printf | grep`.
+#
+# Kazde sprawdzenie wzorca kosztowalo dwa procesy, a polityka robi ich 33 —
+# na Windows tworzenie procesu to ~0,12 s, wiec jedno wywolanie bramki zajmowalo
+# ~2,5 s i suita regresji chodzila 158 s zamiast kilku. Wbudowane dopasowanie
+# nie tworzy procesu wcale.
+#
+# Wzorce to ERE po obu stronach (grep -E i regcomp), wiec skladnia zostaje bez
+# zmian. `nocasematch` zastepuje flage -i i jest wlaczany TYLKO na czas
+# dopasowania — globalnie zmienialby tez `case` nizej (m.in. */tmp/claude/*),
+# czyli poszerzalby polityke przy okazji optymalizacji.
+#
+# Wzorzec MUSI byc nieocytowany: w cudzyslowie [[ =~ ]] traktuje go jak zwykly
+# tekst i bramka przestaje lapac cokolwiek — po cichu, bez bledu.
 has() {
-  printf '%s' "$normalized" | grep -Eqi -- "$1" && return 0
-  return 1
+  local rc
+  shopt -s nocasematch
+  [[ "$normalized" =~ $1 ]] && rc=0 || rc=1
+  shopt -u nocasematch
+  return "$rc"
 }
 
 # True if push targets protected branch ref (main|master|dev), not remote named "dev".
@@ -232,7 +253,7 @@ norm_path() {
   # Porownanie ma dzialac tak samo na POSIX i na Windows: backslash -> slash,
   # male litery, "C:/x" -> "/c/x", bez koncowego slasha.
   local p="${1//\\//}"
-  p=$(printf '%s' "$p" | tr 'A-Z' 'a-z')
+  p=${p,,}   # wbudowane male litery zamiast `printf | tr` — bez procesu
   if [[ "$p" =~ ^([a-z]):/(.*)$ ]]; then
     p="/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
   fi

--- a/tests/test_shell_suites.py
+++ b/tests/test_shell_suites.py
@@ -27,7 +27,13 @@ ROOT = Path(__file__).resolve().parents[1]
 TESTS_DIR = ROOT / "tests"
 
 # Bootstrap odpala kilka pełnych instalacji (uvx-free, ale wiele procesów Pythona).
-SUITE_TIMEOUT_SECONDS = 600
+#
+# 300 s to ~2,5× zapas nad najwolniejszą zmierzoną suitą (bootstrap: 121 s na
+# Windows, reszta poniżej 60 s). Poprzednie 600 s znaczyło, że przy zamulonej
+# maszynie suita mieliła dziesięć minut, zanim powiedziała cokolwiek — a i tak
+# kończyła się błędem. Limit ma zamieniać zamulenie w szybki komunikat, nie
+# przykrywać je czekaniem.
+SUITE_TIMEOUT_SECONDS = 300
 
 BASH_SUITES: tuple[str, ...] = (
     "test_gate_destructive.sh",

--- a/tests/test_shell_suites.py
+++ b/tests/test_shell_suites.py
@@ -15,10 +15,12 @@ pominęła — pilnuje `is_ci()` po stronie samych suit.
 from __future__ import annotations
 
 import ast
+import io
 import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 # Jedno źródło prawdy dla wykrywania Git Bash, CI i formy ścieżki dla basha.
 from test_bash_hook_launcher import is_ci, posix_path, resolve_bash
@@ -28,11 +30,15 @@ TESTS_DIR = ROOT / "tests"
 
 # Bootstrap odpala kilka pełnych instalacji (uvx-free, ale wiele procesów Pythona).
 #
-# 300 s to ~2,5× zapas nad najwolniejszą zmierzoną suitą (bootstrap: 121 s na
-# Windows, reszta poniżej 60 s). Poprzednie 600 s znaczyło, że przy zamulonej
-# maszynie suita mieliła dziesięć minut, zanim powiedziała cokolwiek — a i tak
-# kończyła się błędem. Limit ma zamieniać zamulenie w szybki komunikat, nie
-# przykrywać je czekaniem.
+# Zmierzone czasy pojedynczej suity na Windows: typowo 7-57 s, bootstrap 25-121 s.
+# Ale ta sama maszyna potrafi zamulić tak, że `test_gate_destructive.sh` nie kończy
+# się w 600 s (patrz #24) — przy 41 s w przebiegu obok. Rozrzut jest dwunastokrotny
+# i limit go NIE pokrywa; 300 s leży w środku, świadomie.
+#
+# To jest wybór, nie zapas: zamulenie ma być czerwone i szybkie, a nie ciche przez
+# dziesięć minut. Czerwony z tego limitu znaczy „środowisko stanęło", nie „regresja
+# w kodzie" — komunikat błędu ma to powiedzieć wprost, dlatego `_run_suite` łapie
+# timeout osobno.
 SUITE_TIMEOUT_SECONDS = 300
 
 BASH_SUITES: tuple[str, ...] = (
@@ -86,15 +92,26 @@ class TestExternalSuites(unittest.TestCase):
             argv: Komenda do uruchomienia.
             name: Nazwa pliku suity (do komunikatu błędu).
         """
-        proc = subprocess.run(
-            argv,
-            cwd=str(ROOT),
-            capture_output=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=SUITE_TIMEOUT_SECONDS,
-            check=False,
-        )
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=str(ROOT),
+                capture_output=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=SUITE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            # `TimeoutExpired` niesie to, co suita zdążyła wypisać — bez tego bloku
+            # ginie i zostaje sam traceback, z ktorego nie widać, na czym stanęła.
+            self.fail(
+                f"{name} nie skończył się w {SUITE_TIMEOUT_SECONDS} s i został ubity.\n"
+                "To zwykle znaczy, że stanęło środowisko (patrz #24), nie że jest "
+                "regresja — ostatnia linia poniżej mówi, dokąd suita doszła.\n"
+                f"--- stdout (częściowy) ---\n{exc.stdout or '(pusty)'}\n"
+                f"--- stderr (częściowy) ---\n{exc.stderr or '(pusty)'}"
+            )
         if proc.returncode != 0:
             self.fail(
                 f"{name} zakończył się kodem {proc.returncode}\n"
@@ -173,6 +190,49 @@ class TestExternalSuites(unittest.TestCase):
                 f"{undeclared}"
             ),
         )
+
+
+class TestMissingBashPolicy(unittest.TestCase):
+    """
+    Brak basha: lokalnie skip, na CI błąd.
+
+    Gałąź „na CI to błąd" nie wykonuje się nigdy w normalnym przebiegu — CI chodzi
+    na ubuntu, gdzie bash jest zawsze. Deklaracja „cichy skip odtworzyłby lukę"
+    była więc nieudowodniona; te dwa testy podstawiają brak basha i sprawdzają,
+    że decyzja naprawdę zależy od `is_ci()`.
+    """
+
+    def _run_bash_suites(self, *, on_ci: bool) -> unittest.TestResult:
+        """
+        Odpal `test_bash_suites_pass` z podstawionym brakiem basha.
+
+        Args:
+            on_ci: Co ma zwrócić `is_ci()` w trakcie przebiegu.
+
+        Returns:
+            unittest.TestResult: Wynik pojedynczego testu.
+        """
+        module = sys.modules[__name__]
+        suite = unittest.TestSuite([TestExternalSuites("test_bash_suites_pass")])
+        with (
+            mock.patch.object(module, "resolve_bash", return_value=""),
+            mock.patch.object(module, "is_ci", return_value=on_ci),
+        ):
+            return unittest.TextTestRunner(stream=io.StringIO(), verbosity=0).run(suite)
+
+    def test_missing_bash_locally_skips(self) -> None:
+        """Bez basha lokalnie: skip, nie błąd — goły Windows ma prawo nie mieć Git Bash."""
+        result = self._run_bash_suites(on_ci=False)
+        self.assertEqual(len(result.skipped), 1)
+        self.assertEqual(result.failures, [])
+        self.assertEqual(result.errors, [])
+
+    def test_missing_bash_on_ci_fails(self) -> None:
+        """Bez basha na CI: błąd — cichy skip odtworzyłby lukę, którą ten moduł zamyka."""
+        result = self._run_bash_suites(on_ci=True)
+        self.assertEqual(len(result.failures), 1)
+        self.assertEqual(result.skipped, [])
+        self.assertIn("suity powłoki muszą się wykonać", result.failures[0][1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Objaw

`tests/test_gate_destructive.sh` chodził 158 s na Windows i blokował pełny
`unittest discover`. Na CI (ubuntu) niewidoczne.

## Przyczyna

Polityka sprawdza 33 wzorce, każdy przez `printf | grep` — dwa procesy na
sprawdzenie. Do tego `tr`+`sed` przy normalizacji i `tr` w `norm_path`.
Koszt to wyłącznie tworzenie procesu:

```
1 wywolanie bramki        2,80 s
pusty bash                0,12 s
40x (printf | grep)       4,96 s   (0,124 s za sztuke)
```

Na Linuksie ten sam spawn to ~1 ms — stąd cisza na CI.

## Naprawa

Trzy zamiany na konstrukcje wbudowane basha, zero nowych zależności:

| było | jest |
|---|---|
| `printf \| grep -Eqi` | `[[ =~ ]]` |
| `printf \| tr` + `printf \| sed` | podstawienia parametrów |
| `printf \| tr A-Z a-z` | `${p,,}` |

`nocasematch` jest włączany **tylko na czas dopasowania**. Ustawiony globalnie
zmieniałby też instrukcje `case` niżej w pliku — m.in. `*/tmp/claude/*` —
czyli poszerzałby politykę przy okazji optymalizacji.

## Dowód

Zmierzone na stanie tego brancha (`b4fbca0`), nie sprzed zmian:

```
1 wywolanie bramki                        2,80 s -> 0,46 s
bash tests/test_gate_destructive.sh        158 s -> 45 s
unittest discover -p test_shell_suites.py        Ran 6 tests in 183.972s  OK
uv tool run ty check                             All checks passed!
```

Pełna suita (`Ran 70 tests in 187.834s OK`) była mierzona przed zmianą limitu
w `test_shell_suites.py` i jest tu podana wyłącznie jako punkt odniesienia dla
samej bramki — dowodem dla stanu brancha jest przebieg modułu powyżej.

**Test różnicowy** — stara polityka z `master` i nowa, ten sam korpus
90 komend, decyzja porównana jedna do jednej:

```
[koniec: 0 roznic]
```

Korpus obejmował wielkie litery (`GIT PUSH --FORCE ORIGIN MAIN`), wielokrotne
spacje, `+refspec`, `HEAD:main`, ścieżki Windows, `~`, `/tmp/claude/`, oraz
przypadki które **mają** przechodzić (`git push origin feature/main-menu`,
`git push origin main-backup`).

Obie kopie dogfood (`.claude/hooks/`, `.cursor/hooks/`) zsynchronizowane w tym
samym commicie — inaczej testy porównujące je bajt po bajcie padają.

## Zmiany w `test_shell_suites.py`

Limit pojedynczej suity 600 s -> 300 s, plus trzy rzeczy wykazane przez
`/review-tests` na tym pliku:

1. **Przekroczenie limitu leciało jako niezłapany `TimeoutExpired`** — w raporcie
   zostawał sam traceback. Częściowy stdout istnieje w wyjątku i był wyrzucany.
   Zweryfikowane z limitem 1 s: komunikat niesie teraz listę przypadków, które
   suita zdążyła wypisać.
2. **Uzasadnienie limitu było nieuczciwe** — mówiło o „2,5× zapasie nad
   najwolniejszą zmierzoną suitą (121 s)", pomijając zmierzony outlier: ta sama
   suita nie skończyła się w 600 s przy 41 s w przebiegu obok. Limit nie ma
   zapasu, jest świadomym wyborem — komentarz mówi to teraz wprost.
3. **Gałąź „brak basha na CI to błąd" nie wykonywała się nigdy** (CI to ubuntu),
   więc deklaracja z docstringa była nieudowodniona. `TestMissingBashPolicy`
   podstawia brak basha i sprawdza obie decyzje.

## Poza zakresem

Sporadyczne przekraczanie czasu przez `test_shell_suites` pod `unittest` na
Windows — te same suity odpalone bezpośrednio chodzą zawsze 86-104 s.
Osobno w #24.

Closes #23
