### PR TITLE
Allow redirects to /dev/null without a permission prompt

### DIFF
--- a/.claude/hooks/gate-destructive.sh
+++ b/.claude/hooks/gate-destructive.sh
@@ -285,9 +285,13 @@ outside_target() {
     tok="${tok%[\"\']}"
     [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
     tok_n=$(norm_path "$tok")
-    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
     case "$tok_n" in
+      # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
       */tmp/claude/*|*/temp/claude/*) continue ;;
+      # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
+      # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
+      # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
+      /dev/null|/dev/stdout|/dev/stderr) continue ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/.claude/hooks/gate-destructive.sh
+++ b/.claude/hooks/gate-destructive.sh
@@ -270,11 +270,15 @@ project_root() {
 
 # Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
 outside_target() {
-  local root_n home_n tok tok_n
+  local root_n home_n tok tok_n prev="" cur=""
   root_n=$(norm_path "$(project_root)")
   home_n=$(norm_path "${HOME:-}")
   set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
   for tok in $command; do
+    # Poprzedni token — potrzebny, zeby odroznic cel przekierowania od zwyklego
+    # argumentu. Przypisanie na gorze petli, bo ponizsze `continue` je omijaja.
+    prev="$cur"
+    cur="$tok"
     case "$tok" in
       -*) continue ;;
       /*|~*|[A-Za-z]:[\\/]*) ;;
@@ -291,7 +295,15 @@ outside_target() {
       # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
       # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
       # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
-      /dev/null|/dev/stdout|/dev/stderr) continue ;;
+      #
+      # Wyjatek obowiazuje TYLKO dla celu przekierowania (`>`, `>>`, `2>`).
+      # W roli zwyklego argumentu ten sam token niszczy dane — `mv plik /dev/null`
+      # kasuje plik bezpowrotnie — wiec tam pytamy dalej.
+      /dev/null|/dev/stdout|/dev/stderr)
+        case "$prev" in
+          *'>') continue ;;
+        esac
+        ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/.cursor/hooks/gate-destructive.sh
+++ b/.cursor/hooks/gate-destructive.sh
@@ -285,9 +285,13 @@ outside_target() {
     tok="${tok%[\"\']}"
     [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
     tok_n=$(norm_path "$tok")
-    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
     case "$tok_n" in
+      # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
       */tmp/claude/*|*/temp/claude/*) continue ;;
+      # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
+      # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
+      # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
+      /dev/null|/dev/stdout|/dev/stderr) continue ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/.cursor/hooks/gate-destructive.sh
+++ b/.cursor/hooks/gate-destructive.sh
@@ -270,11 +270,15 @@ project_root() {
 
 # Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
 outside_target() {
-  local root_n home_n tok tok_n
+  local root_n home_n tok tok_n prev="" cur=""
   root_n=$(norm_path "$(project_root)")
   home_n=$(norm_path "${HOME:-}")
   set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
   for tok in $command; do
+    # Poprzedni token — potrzebny, zeby odroznic cel przekierowania od zwyklego
+    # argumentu. Przypisanie na gorze petli, bo ponizsze `continue` je omijaja.
+    prev="$cur"
+    cur="$tok"
     case "$tok" in
       -*) continue ;;
       /*|~*|[A-Za-z]:[\\/]*) ;;
@@ -291,7 +295,15 @@ outside_target() {
       # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
       # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
       # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
-      /dev/null|/dev/stdout|/dev/stderr) continue ;;
+      #
+      # Wyjatek obowiazuje TYLKO dla celu przekierowania (`>`, `>>`, `2>`).
+      # W roli zwyklego argumentu ten sam token niszczy dane — `mv plik /dev/null`
+      # kasuje plik bezpowrotnie — wiec tam pytamy dalej.
+      /dev/null|/dev/stdout|/dev/stderr)
+        case "$prev" in
+          *'>') continue ;;
+        esac
+        ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/templates/shared/guards/gate-destructive.sh
+++ b/templates/shared/guards/gate-destructive.sh
@@ -285,9 +285,13 @@ outside_target() {
     tok="${tok%[\"\']}"
     [[ "$tok" == '~'* ]] && tok="${home_n}${tok#\~}"
     tok_n=$(norm_path "$tok")
-    # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
     case "$tok_n" in
+      # Katalog tymczasowy agenta jest z zalozenia jednorazowy — nie warty promptu.
       */tmp/claude/*|*/temp/claude/*) continue ;;
+      # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
+      # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
+      # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
+      /dev/null|/dev/stdout|/dev/stderr) continue ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/templates/shared/guards/gate-destructive.sh
+++ b/templates/shared/guards/gate-destructive.sh
@@ -270,11 +270,15 @@ project_root() {
 
 # Zwraca pierwszy argument-sciezke, ktory wychodzi poza projekt (albo nic).
 outside_target() {
-  local root_n home_n tok tok_n
+  local root_n home_n tok tok_n prev="" cur=""
   root_n=$(norm_path "$(project_root)")
   home_n=$(norm_path "${HOME:-}")
   set -f  # bez tego glob rozwinalby "*" z komendy na pliki z cwd
   for tok in $command; do
+    # Poprzedni token — potrzebny, zeby odroznic cel przekierowania od zwyklego
+    # argumentu. Przypisanie na gorze petli, bo ponizsze `continue` je omijaja.
+    prev="$cur"
+    cur="$tok"
     case "$tok" in
       -*) continue ;;
       /*|~*|[A-Za-z]:[\\/]*) ;;
@@ -291,7 +295,15 @@ outside_target() {
       # Urzadzenia puste nie przechowuja nic, wiec przekierowanie tam nie jest
       # zmiana, ktora git mialby odzyskiwac. Lista jest zamknieta, nie prefiksem
       # `/dev/*`: /dev/sda czy /dev/tty to juz zapis, ktory chcemy widziec.
-      /dev/null|/dev/stdout|/dev/stderr) continue ;;
+      #
+      # Wyjatek obowiazuje TYLKO dla celu przekierowania (`>`, `>>`, `2>`).
+      # W roli zwyklego argumentu ten sam token niszczy dane — `mv plik /dev/null`
+      # kasuje plik bezpowrotnie — wiec tam pytamy dalej.
+      /dev/null|/dev/stdout|/dev/stderr)
+        case "$prev" in
+          *'>') continue ;;
+        esac
+        ;;
     esac
     [[ "$tok_n" == "$root_n" || "$tok_n" == "$root_n"/* ]] && continue
     set +f

--- a/tests/test_gate_destructive.sh
+++ b/tests/test_gate_destructive.sh
@@ -131,6 +131,16 @@ run_hook "cat README.md > NUL" allow
 # Lista jest zamknieta: reszta /dev/* to nadal zapis poza repo.
 run_hook "echo x > /dev/sda" ask
 run_hook "echo x > /dev/tty" ask
+# ...a wyjatek dotyczy wylacznie CELU przekierowania. Ten sam token w roli
+# zwyklego argumentu niszczy dane (`mv plik /dev/null` kasuje plik bezpowrotnie),
+# wiec tam pytamy dalej. Regresja: pierwsza wersja tego wyjatku dzialala na
+# kazdym tokenie i przepuszczala `mv` oraz `cp` jako `allow`.
+run_hook "mv README.md /dev/null" ask
+run_hook "cp -r docs /dev/stdout" ask
+run_hook "rm /dev/null" ask
+# Operator z deskryptorem i dopisywanie licza sie jako przekierowanie.
+run_hook "cat README.md 2> /dev/null" allow
+run_hook "make build >> /dev/null" allow
 
 # --- fail-closed -------------------------------------------------------------
 # Nieoczekiwany exit != 0 bez wczesniejszego emit → ask + exit 0 (zeby failClosed

--- a/tests/test_gate_destructive.sh
+++ b/tests/test_gate_destructive.sh
@@ -118,6 +118,20 @@ run_hook "sed -i s/a/b/ README.md" allow
 # Katalog tymczasowy agenta jest jednorazowy — prompt bylby szumem.
 run_hook "touch /tmp/claude/session/scratch.txt" allow
 
+# Urzadzenia puste: przekierowanie tam nic nie traci. Regresja — token sklejony
+# (`2>/dev/null`) przechodzil zawsze, bo zaczyna sie od cyfry i wypada z petli
+# po tokenach; rozdzielony spacja byl liczony jako sciezka poza repo i pytal.
+run_hook "cat README.md > /dev/null" allow
+run_hook "cat README.md 2>/dev/null" allow
+run_hook "bash scripts/bootstrap-project.sh > /dev/null 2>&1" allow
+run_hook "echo diag > /dev/stderr" allow
+run_hook "echo diag > /dev/stdout" allow
+# Windowsowy odpowiednik nie wyglada na sciezke, wiec nie wchodzi do petli.
+run_hook "cat README.md > NUL" allow
+# Lista jest zamknieta: reszta /dev/* to nadal zapis poza repo.
+run_hook "echo x > /dev/sda" ask
+run_hook "echo x > /dev/tty" ask
+
 # --- fail-closed -------------------------------------------------------------
 # Nieoczekiwany exit != 0 bez wczesniejszego emit → ask + exit 0 (zeby failClosed
 # w Cursor nie zablokowal mimo poprawnej decyzji).


### PR DESCRIPTION
## Summary

`gate-destructive.sh` pytał o zgodę na przekierowanie do `/dev/null`, jeśli było zapisane ze spacją. `outside_target()` iteruje po tokenach komendy i każdy zaczynający się od `/` liczy jako ścieżkę poza repo — a `/dev/null` nią nie jest w żadnym użytecznym sensie: nic tam nie ginie i git nie ma czego odzyskiwać.

Forma sklejona `2>/dev/null` przechodziła, bo token zaczyna się od cyfry i wypada z pętli przez `*) continue`. Ta sama intencja dawała dwie różne decyzje w zależności od spacji:

```
cat README.md > /dev/null   →  ask  "zmiana poza projektem: /dev/null"
cat README.md 2>/dev/null   →  allow
```

Wyjątek jest **zamkniętą listą** (`/dev/null`, `/dev/stdout`, `/dev/stderr`), nie prefiksem `/dev/*` — zapis do `/dev/sda` czy `/dev/tty` ma nadal pytać i ma na to testy.

## Dwa commity, bo pierwsza wersja była zła

`f0b21c1` zwalniał token **niezależnie od pozycji w komendzie**. To rozbroiło politykę na operacjach, których ona właśnie pilnuje — `mv plik /dev/null` kasuje plik bezpowrotnie:

```
                          origin/master   f0b21c1   385b270
mv README.md /dev/null    ask             allow     ask
cp -r docs /dev/stdout    ask             allow     ask
cat README.md > /dev/null ask             allow     allow
```

Złapała to oś Spec z `/code-review` (`/review-bugbot` przepuścił — jego reguły celują w monorepo Django + Expo, więc dla guardraili miał tylko reguły ogólne).

`385b270` uzależnia wyjątek od poprzedniego tokenu: urządzenie puste jest pomijane tylko wtedy, gdy stoi za operatorem przekierowania (`>`, `>>`, `2>`). Przypisanie `prev` siedzi na górze pętli, bo kolejne `continue` omijają jej koniec; obie zmienne mają jawną wartość początkową, inaczej `set -u` przerywa politykę przy pierwszym tokenie.

## Test plan

- [x] `bash tests/test_gate_destructive.sh` — zielone, 11 nowych przypadków
- [x] `bash tests/test_guard_adapter.sh` — zielone (kontrakt Cursora nietknięty)
- [x] `uv run python -m unittest discover -s tests` — 74 testy, 1 skip platformowy (`test_gate_file_writes.py`, wariant POSIX na Windows), 1 failure: **znany timeout z #24**, nie regresja
- [x] Kopie `.claude/hooks/` i `.cursor/hooks/` zsynchronizowane z szablonem; pilnuje tego `tests/test_generated_artifacts.py:129` (porównanie bajt w bajt)
- [x] Kryterium ręczne z issue zwraca `allow`

Nowe przypadki dzielą się na trzy grupy: przechodzą (`> /dev/null`, `2>/dev/null`, `2> /dev/null`, `>> /dev/null`, `> /dev/stdout`, `> /dev/stderr`, `> NUL`), pytają mimo urządzenia pustego w roli argumentu (`mv`, `cp`, `rm`), pytają bo lista jest zamknięta (`> /dev/sda`, `> /dev/tty`).

### O tym jednym failurze

`test_shell_suites.test_bash_suites_pass` ubił `test_gate_destructive.sh` po 300 s. Przechwycony przez wrapper stdout tej suity kończy się jednak na `All gate-destructive checks passed.` — wszystkie asercje przeszły, proces nie wrócił w oknie. Uruchomiona bezpośrednio zajmuje **29 s** przy limicie 300 s; 11 nowych przypadków to ok. 15% jej czasu. Sam test nazywa ten stan w komunikacie: „To zwykle znaczy, że stanęło środowisko (patrz #24), nie że jest regresja".

`> NUL` przechodzi bez wpisu na liście — token nie wygląda na ścieżkę, więc nigdy nie wchodzi do pętli. Test to utrwala: gdyby ktoś rozszerzył filtr tokenów, przypadek się wywali i decyzja wróci na stół.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
