### PR TITLE
Install client files into a workspace from the MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ Zapisuje m.in. MCP per klient (`--preset`, `--language`, `--codegen`, `--clients
 
 **Declarative sync klientów:** domyślnie bootstrap **usuwa** kitowe pliki klientów spoza `--clients` (np. przełączenie z `--clients all` na `--clients claude` sprząta `.cursor/`, `.codex/` itd. wygenerowane przy poprzednim bootstrapie). Flaga `--keep-unselected-clients` wyłącza to sprzątanie — zostają pliki wszystkich klientów kiedykolwiek bootstrapowanych.
 
+### Bootstrap bez klona kita — narzędzie MCP `bootstrap_workspace`
+
+Jeśli projekt ma już podłączony serwer MCP `project-guides`, kita nie trzeba klonować ani ręcznie odpalać skryptu — serwer ma szablony pod ręką i uruchamia ten sam `bootstrap-project.sh` u siebie. Poproś agenta o wywołanie narzędzia:
+
+```text
+bootstrap_workspace()                          # dry run — tylko lista plików
+bootstrap_workspace(dry_run=False)             # instalacja
+bootstrap_workspace(clients="claude", with_overlay=True, dry_run=False)
+```
+
+Argumenty (`clients`, `preset`, `language`, `codegen`, `with_overlay`, `keep_unselected_clients`) odpowiadają flagom skryptu; pominięte biorą wartość z parametrów startowych serwera MCP. Cel zapisu to `--workspace` / `GUIDES_WORKSPACE` — **bez niego narzędzie odmawia**, zamiast zapisywać do katalogu, z którego przypadkiem wystartował proces serwera.
+
+`dry_run=True` jest domyślne i nic nie zapisuje: skrypt leci na kopii kitowej powierzchni repo w katalogu tymczasowym, a raport pokazuje pliki nowe, nadpisane i **usunięte** przez sprzątanie klientów spoza `--clients`. Plan pochodzi więc z faktycznego przebiegu skryptu, nie z drugiej listy ścieżek w Pythonie.
+
+> **Uwaga na bramki.** Hooki kita (`PreToolUse`) łapią `Bash`, `PowerShell` i `Edit|Write|MultiEdit|NotebookEdit` — nie nazwy narzędzi MCP. To jedyne zapisujące narzędzie tego serwera i hooki go **nie zatrzymają**; `dry_run=True` jako domyślka plus wymóg jawnego `dry_run=False` są tu całą ochroną. Reszta narzędzi serwera pozostaje tylko do odczytu.
+
 ## MCP w innych klientach (multi-client)
 
 Kanon treści: `templates/shared/{agents,rules}`. Adaptery IDE trzymają tylko format MCP / ścieżki natywne. Bootstrap `--clients` instaluje wybrane pakiety (default `all`).

--- a/src/guides/bootstrap.py
+++ b/src/guides/bootstrap.py
@@ -1,0 +1,260 @@
+"""Wykonanie ``scripts/bootstrap-project.sh`` z poziomu serwera MCP.
+
+Skrypt bash zostaje **jedynym źródłem prawdy** o tym, co bootstrap gdzie kładzie.
+Ten moduł tylko go uruchamia (Windows: Git Bash, ta sama logika co
+``templates/shared/guards/invoke-hook.js``) i — dla trybu dry-run — robi to
+w sandboxie, żeby plan zmian pochodził z faktycznego przebiegu skryptu, a nie
+z drugiej, rozjeżdżającej się listy ścieżek w Pythonie.
+"""
+
+from __future__ import annotations
+
+import filecmp
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+SCRIPT_REL_PATH = "scripts/bootstrap-project.sh"
+
+# Powierzchnia repo aplikacji, którą bootstrap czyta lub zapisuje. Sandbox dry-runu
+# dostaje kopię dokładnie tych ścieżek — dzięki temu „nie nadpisuj jeśli istnieje"
+# (AGENTS.md, BUGBOT.md, .ai/project.md), scalanie `.claude/settings.json` i sprzątanie
+# klientów spoza `--clients` zachowują się w planie tak jak zachowają się na żywo.
+KIT_SURFACE: tuple[str, ...] = (
+    ".agents",
+    ".ai",
+    ".claude",
+    ".codex",
+    ".cursor",
+    ".github/copilot-instructions.md",
+    ".github/prompts",
+    ".kilocode",
+    ".kiro",
+    ".mcp.json",
+    ".opencode",
+    ".vscode",
+    "AGENTS.md",
+    "BUGBOT.md",
+    "git-hooks",
+    "opencode.json",
+)
+
+_TIMEOUT_SECONDS = 600
+
+
+class BootstrapError(RuntimeError):
+    """Bootstrap nie mógł zostać uruchomiony albo zakończył się błędem."""
+
+
+@dataclass
+class BootstrapPlan:
+    """Różnica między stanem repo a wynikiem przebiegu skryptu w sandboxie."""
+
+    created: list[str] = field(default_factory=list)
+    modified: list[str] = field(default_factory=list)
+    deleted: list[str] = field(default_factory=list)
+    unchanged: list[str] = field(default_factory=list)
+    script_output: str = ""
+
+    @property
+    def touches_disk(self) -> bool:
+        """Czy realny przebieg w ogóle coś by zmienił."""
+        return bool(self.created or self.modified or self.deleted)
+
+
+def find_bash() -> str:
+    """
+    Znajdź interpreter bash do uruchomienia skryptu polityki/bootstrapu.
+
+    Na Linuksie i macOS ``bash`` jest w PATH. Windows go tam nie ma, więc (i tylko
+    tam) szukamy Git Basha pod typowymi ścieżkami instalacji — ta sama kolejność
+    kandydatów co w ``templates/shared/guards/invoke-hook.js``.
+
+    Returns:
+        str: Ścieżka do bash.exe (Windows) albo ``"bash"``.
+    """
+    if os.name != "nt":
+        return "bash"
+    program_files = os.environ.get("ProgramFiles") or "C:\\Program Files"
+    local_app_data = os.environ.get("LocalAppData") or ""
+    candidates = [
+        Path(program_files) / "Git" / "bin" / "bash.exe",
+        Path(program_files) / "Git" / "usr" / "bin" / "bash.exe",
+    ]
+    if local_app_data:
+        candidates.append(Path(local_app_data) / "Programs" / "Git" / "bin" / "bash.exe")
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return "bash"
+
+
+def _script_path(kit_root: Path) -> Path:
+    script = kit_root / SCRIPT_REL_PATH
+    if not script.is_file():
+        raise BootstrapError(f"Brak skryptu bootstrapu: {script}")
+    return script
+
+
+def build_args(
+    *,
+    kit_root: Path,
+    target: Path,
+    clients: str = "all",
+    preset: str = "_base",
+    language: str = "pl",
+    codegen: str = "orval",
+    from_src: str | None = None,
+    with_overlay: bool = False,
+    with_profile: bool = False,
+    skip_agents: bool = False,
+    keep_unselected_clients: bool = False,
+) -> list[str]:
+    """
+    Zbuduj listę argumentów wywołania ``bootstrap-project.sh``.
+
+    Args:
+        kit_root: Root repozytorium instruction-kit (źródło szablonów).
+        target: Repo aplikacji, do którego lądują pliki.
+        clients: Wartość ``--clients`` (już zwalidowana przez ``guides.clients``).
+        preset: Kategoria presetu, np. ``_base``, ``shop``.
+        language: Język prozy instrukcji (``pl``/``en``).
+        codegen: Generator klienta API (``orval``/``none``/``graphql``).
+        from_src: Wartość ``--from``; domyślnie lokalna ścieżka kita.
+        with_overlay: Dołóż ``--with-overlay``.
+        with_profile: Dołóż ``--with-profile``.
+        skip_agents: Dołóż ``--skip-agents``.
+        keep_unselected_clients: Nie sprzątaj plików klientów spoza ``--clients``.
+
+    Returns:
+        list[str]: Argv dla bash (bez samego interpretera).
+    """
+    script = _script_path(kit_root)
+    args = [
+        str(script).replace("\\", "/"),
+        str(target).replace("\\", "/"),
+        "--preset",
+        preset,
+        "--language",
+        language,
+        "--codegen",
+        codegen,
+        "--clients",
+        clients,
+        "--from",
+        (from_src or str(kit_root)).replace("\\", "/"),
+    ]
+    if with_overlay:
+        args.append("--with-overlay")
+    if with_profile:
+        args.append("--with-profile")
+    if skip_agents:
+        args.append("--skip-agents")
+    if keep_unselected_clients:
+        args.append("--keep-unselected-clients")
+    return args
+
+
+def run_bootstrap(**kwargs) -> str:
+    """
+    Uruchom bootstrap na wskazanym katalogu (**zapisuje na dysk**).
+
+    Args:
+        **kwargs: Jak w :func:`build_args` (``kit_root``, ``target``, flagi).
+
+    Returns:
+        str: Stdout skryptu (lista założonych plików).
+
+    Raises:
+        BootstrapError: Brak skryptu, brak basha, timeout albo niezerowy exit code.
+    """
+    argv = build_args(**kwargs)
+    bash = find_bash()
+    try:
+        result = subprocess.run(
+            [bash, "--noprofile", "--norc", *argv],
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise BootstrapError(
+            f"Nie znaleziono interpretera bash (`{bash}`). Na Windows zainstaluj Git for Windows."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise BootstrapError(
+            f"Bootstrap przekroczył {_TIMEOUT_SECONDS}s i został przerwany."
+        ) from exc
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip() or "(pusty stderr)"
+        raise BootstrapError(
+            f"bootstrap-project.sh zakończył się kodem {result.returncode}: {stderr}"
+        )
+    return (result.stdout or "").strip()
+
+
+def _seed_sandbox(workspace_root: Path, sandbox: Path) -> None:
+    """Skopiuj do sandboxu tylko te ścieżki repo, których dotyka bootstrap."""
+    for rel in KIT_SURFACE:
+        src = workspace_root / rel
+        if not src.exists():
+            continue
+        dest = sandbox / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_dir():
+            shutil.copytree(src, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(src, dest)
+
+
+def _relative_files(root: Path) -> set[str]:
+    return {
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+def plan_bootstrap(*, workspace_root: Path, **kwargs) -> BootstrapPlan:
+    """
+    Policz, co bootstrap by zmienił — bez dotykania repo aplikacji.
+
+    Skrypt leci naprawdę, ale na kopii kitowej powierzchni repo w katalogu
+    tymczasowym (patrz :data:`KIT_SURFACE`). Wynik porównujemy z oryginałem,
+    więc plan zna też pliki, które sprzątanie klientów spoza ``--clients``
+    by **usunęło**.
+
+    Args:
+        workspace_root: Repo aplikacji (tylko odczyt).
+        **kwargs: Jak w :func:`build_args`, bez ``target``.
+
+    Returns:
+        BootstrapPlan: Listy created/modified/deleted/unchanged + stdout skryptu.
+
+    Raises:
+        BootstrapError: Jak w :func:`run_bootstrap`.
+    """
+    kwargs.pop("target", None)
+    with tempfile.TemporaryDirectory(prefix="guides-bootstrap-dry-") as tmp:
+        sandbox = Path(tmp) / "workspace"
+        sandbox.mkdir(parents=True)
+        _seed_sandbox(workspace_root, sandbox)
+        before = _relative_files(sandbox)
+
+        output = run_bootstrap(target=sandbox, **kwargs)
+
+        after = _relative_files(sandbox)
+        plan = BootstrapPlan(script_output=output)
+        for rel in sorted(after - before):
+            plan.created.append(rel)
+        for rel in sorted(before - after):
+            plan.deleted.append(rel)
+        for rel in sorted(before & after):
+            same = filecmp.cmp(workspace_root / rel, sandbox / rel, shallow=False)
+            (plan.unchanged if same else plan.modified).append(rel)
+        return plan

--- a/src/guides/kit_status.py
+++ b/src/guides/kit_status.py
@@ -71,8 +71,10 @@ def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
         return (
             "# Kit status: brak stampu\n\n"
             f"Nie znaleziono `{STAMP_REL_PATH}` w repo aplikacji — projekt nie był "
-            "bootstrapowany wersją kita ze stampem (albo plik usunięty). "
-            "Uruchom `bootstrap-project.sh` żeby go założyć."
+            "bootstrapowany wersją kita ze stampem (albo plik usunięty).\n\n"
+            "Załóż go narzędziem MCP `bootstrap_workspace` — najpierw bez argumentów "
+            "(dry run pokaże listę plików), potem `dry_run=False` żeby zainstalować. "
+            "Alternatywa bez MCP: lokalny klon kita i `bootstrap-project.sh`."
         )
 
     stamp_commit = stamp.get("kit_commit") or ""
@@ -125,8 +127,9 @@ def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
         lines.extend(f"- `{f}`" for f in sorted(set(changed_files)))
         lines.append("")
         lines.append(
-            "Uruchom ponownie `bootstrap-project.sh` (te same flagi co poprzednio) "
-            "żeby dostać aktualizację. **Nadpisze** `.claude/agents/`, `.cursor/agents/`, "
+            "Zaktualizuj narzędziem MCP `bootstrap_workspace` (dry run najpierw) albo "
+            "ponownym `bootstrap-project.sh` z tymi samymi flagami co poprzednio. "
+            "**Nadpisze** `.claude/agents/`, `.cursor/agents/`, "
             "`.claude/commands/`, `mcp.json` — jeśli je ręcznie edytowałeś, zrób "
             "`git diff` najpierw."
         )

--- a/src/guides/server.py
+++ b/src/guides/server.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
+from guides.bootstrap import BootstrapError, plan_bootstrap, run_bootstrap
 from guides.clients import (
     expand_clients,
     format_clients_arg,
@@ -30,7 +31,9 @@ mcp = FastMCP(
         "nad architekturą/infra — architecture. Overlay projektu zawiera unikalne ścieżki i taski. "
         "Język prozy (odpowiedzi, docstringi, body issue/commit) ustawia --language / GUIDES_LANGUAGE; "
         "tytuły issue/PR/branch zawsze po angielsku. Użyj get_language. "
-        "Klienci AI (--clients) to metadane instalacji — get_clients; treść bundle bez zmian."
+        "Klienci AI (--clients) to metadane instalacji — get_clients; treść bundle bez zmian. "
+        "Pliki kita (hooki, agenci, komendy) instaluje bootstrap_workspace — jedyne narzędzie "
+        "zapisujące, domyślnie dry_run=True."
     ),
 )
 
@@ -41,6 +44,7 @@ _extra_overlays: list[Path] = []
 _language_override: str | None = None
 _codegen_override: str | None = None
 _clients: list[str] = ["all"]
+_preset: str | None = None
 
 
 def _get_profile_path() -> Path:
@@ -237,6 +241,135 @@ def check_kit_status() -> str:
     return check_kit_updates(kit_root=resolved.kit_root, workspace_root=resolved.workspace_root)
 
 
+def _require_workspace() -> Path:
+    """Zwróć root repo aplikacji albo wyjaśnij, czego brakuje (nigdy nie zgaduj cwd)."""
+    if _workspace_root is None:
+        raise BootstrapError(
+            "Brak roota repo aplikacji. Uruchom serwer MCP z `--workspace /sciezka/do/repo` "
+            "albo ustaw GUIDES_WORKSPACE. Bootstrap nie zapisze do bieżącego katalogu "
+            "procesu serwera — to nie musi być twoje repo."
+        )
+    return _workspace_root
+
+
+def _bootstrap_kwargs(
+    clients: str | None,
+    preset: str | None,
+    language: str | None,
+    codegen: str | None,
+) -> dict:
+    """Złóż flagi bootstrapu: jawne argumenty narzędzia > ustawienia startowe serwera."""
+    resolved = _get_resolved()
+    return {
+        "kit_root": resolved.kit_root,
+        "clients": format_clients_arg(parse_clients(clients) if clients else _clients),
+        "preset": preset or _preset or "_base",
+        "language": normalize_language(language) if language else resolved.language,
+        "codegen": (
+            normalize_codegen(codegen, load_manifest(_kit_root)) if codegen else resolved.codegen
+        ),
+        "from_src": str(resolved.kit_root),
+    }
+
+
+@mcp.tool()
+def bootstrap_workspace(
+    clients: str | None = None,
+    preset: str | None = None,
+    language: str | None = None,
+    codegen: str | None = None,
+    with_overlay: bool = False,
+    keep_unselected_clients: bool = False,
+    dry_run: bool = True,
+) -> str:
+    """
+    Zainstaluj pliki kita (hooki, agenci, komendy, mcp.json, stamp) w repo aplikacji.
+
+    Jedyne narzędzie MCP, które **zapisuje na dysk** — reszta serwera jest tylko do
+    odczytu. Bez tego trzeba sklonować kit lokalnie i ręcznie odpalić
+    ``scripts/bootstrap-project.sh``; tu ten sam skrypt uruchamia serwer, który już
+    ma wszystkie szablony pod ręką.
+
+    ``dry_run=True`` jest domyślne i nic nie zapisuje: skrypt leci na kopii kitowej
+    powierzchni repo w katalogu tymczasowym, a wynikiem jest lista plików, które
+    powstałyby, zostałyby nadpisane albo usunięte. Zapis wymaga jawnego
+    ``dry_run=False`` — hooki ``PreToolUse`` łapią ``Bash``/``Edit``/``Write``,
+    a nie nazwy narzędzi MCP, więc ta domyślka jest tu jedyną bramką.
+
+    Args:
+        clients: ``--clients``: all | cursor | claude | codex | vscode | kiro | kilo |
+            antigravity | opencode (po przecinku). Domyślnie: wartość startowa serwera.
+        preset: Kategoria presetu (``_base``, ``shop``). Domyślnie: preset serwera.
+        language: Język prozy ``pl``/``en``. Domyślnie: język bieżącego profilu.
+        codegen: ``orval``/``none``/``graphql``. Domyślnie: codegen bieżącego profilu.
+        with_overlay: Skopiuj szablon ``.ai/project.md``, jeśli repo go nie ma.
+        keep_unselected_clients: Nie usuwaj kitowych plików klientów spoza ``clients``.
+        dry_run: ``True`` (domyślnie) — tylko plan. ``False`` — faktyczny zapis.
+
+    Returns:
+        str: Markdown — plan zmian (dry run) albo raport z instalacji i stampu.
+    """
+    try:
+        workspace = _require_workspace()
+        kwargs = _bootstrap_kwargs(clients, preset, language, codegen)
+        if kwargs["kit_root"].resolve() == workspace.resolve():
+            raise BootstrapError(
+                f"Workspace i kit to ten sam katalog (`{workspace}`). Bootstrap uruchamia się "
+                "w repo aplikacji, nie w repo kita."
+            )
+        kwargs.update(
+            with_overlay=with_overlay,
+            keep_unselected_clients=keep_unselected_clients,
+        )
+        flags = (
+            f"--preset {kwargs['preset']} --language {kwargs['language']} "
+            f"--codegen {kwargs['codegen']} --clients {kwargs['clients']}"
+        )
+        header = [
+            f"- Workspace: `{workspace}`",
+            f"- Kit: `{kwargs['kit_root']}`",
+            f"- Flagi: `{flags}`",
+            "",
+        ]
+
+        if dry_run:
+            plan = plan_bootstrap(workspace_root=workspace, **kwargs)
+            lines = ["# bootstrap_workspace — dry run (nic nie zapisano)", "", *header]
+            for title, paths in (
+                ("Nowe pliki", plan.created),
+                ("Nadpisane", plan.modified),
+                ("Usunięte przy sprzątaniu klientów", plan.deleted),
+            ):
+                if paths:
+                    lines.append(f"## {title} ({len(paths)})")
+                    lines.append("")
+                    lines.extend(f"- `{p}`" for p in paths)
+                    lines.append("")
+            if plan.unchanged:
+                lines.append(f"## Bez zmian ({len(plan.unchanged)})")
+                lines.append("")
+            if not plan.touches_disk:
+                lines.append(
+                    "Repo jest już zbootstrapowane tymi flagami — nic by się nie zmieniło."
+                )
+                lines.append("")
+            lines.append(
+                "Żeby zastosować: wywołaj ponownie z `dry_run=False`. To jedyne narzędzie "
+                "MCP tego serwera, które pisze po repo — hooki kita go nie zatrzymają."
+            )
+            return "\n".join(lines)
+
+        output = run_bootstrap(target=workspace, **kwargs)
+        stamp = workspace / ".ai" / ".kit-bootstrap.json"
+        lines = ["# bootstrap_workspace — zainstalowano", "", *header, "```", output, "```", ""]
+        stamp_state = "zapisany" if stamp.is_file() else "**BRAK — sprawdź wyjście skryptu**"
+        lines.append(f"- Stamp: `{stamp}` — {stamp_state}")
+        lines.append("- Zrestartuj IDE w repo aplikacji, żeby wczytało hooki i komendy.")
+        return "\n".join(lines)
+    except (BootstrapError, ValueError, RuntimeError) as exc:
+        return f"# bootstrap_workspace: błąd\n\n{exc}"
+
+
 @mcp.tool()
 def list_modules() -> str:
     """
@@ -352,7 +485,7 @@ def _register_bundle_resources() -> None:
 def main() -> None:
     """Entrypoint CLI serwera MCP."""
     global _profile_path, _kit_root, _workspace_root, _extra_overlays
-    global _language_override, _codegen_override, _clients
+    global _language_override, _codegen_override, _clients, _preset
 
     parser = argparse.ArgumentParser(description="Instruction-kit MCP server")
     parser.add_argument(
@@ -438,6 +571,7 @@ def main() -> None:
         parser.error(f"--clients: {exc}")
 
     preset = args.preset or os.environ.get("GUIDES_PRESET")
+    _preset = preset
     profile_arg = args.profile
     env_profile = os.environ.get("GUIDES_PROFILE")
 

--- a/src/guides/server.py
+++ b/src/guides/server.py
@@ -346,7 +346,13 @@ def bootstrap_workspace(
                     lines.extend(f"- `{p}`" for p in paths)
                     lines.append("")
             if plan.unchanged:
-                lines.append(f"## Bez zmian ({len(plan.unchanged)})")
+                # Świadomie licznik, nie sekcja: przy `--clients all` to grubo ponad sto
+                # plików, których bootstrap i tak nie tknie. Nagłówek `##` obiecywałby
+                # wyliczenie, więc raport urywałby się na pustej sekcji.
+                lines.append(
+                    f"Bez zmian: {len(plan.unchanged)} plików kita już zgodnych "
+                    "z tą wersją (nie wyliczam ich)."
+                )
                 lines.append("")
             if not plan.touches_disk:
                 lines.append(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -159,6 +159,20 @@ class TestServerTool(_BootstrapTestCase):
         self.assertTrue((self.workspace / ".ai" / ".kit-bootstrap.json").is_file())
         self.assertTrue((self.workspace / ".claude" / "hooks" / "gate-destructive.sh").is_file())
 
+    def test_report_has_no_empty_sections(self) -> None:
+        """Każdy nagłówek `##` w raporcie musi mieć pod sobą wyliczenie."""
+        server.bootstrap_workspace(dry_run=False)
+        out = server.bootstrap_workspace()
+
+        self.assertIn("Bez zmian:", out)
+        self.assertNotIn("## Bez zmian", out)
+        lines = out.splitlines()
+        for index, line in enumerate(lines):
+            if not line.startswith("## "):
+                continue
+            body = [rest for rest in lines[index + 1 :] if rest.strip()]
+            self.assertTrue(body and body[0].startswith("- `"), msg=f"pusta sekcja: {line}")
+
     def test_missing_workspace_errors_instead_of_writing_cwd(self) -> None:
         """Brak --workspace: błąd, a bieżący katalog procesu zostaje nietknięty."""
         server._workspace_root = None

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,191 @@
+"""Testy bootstrap_workspace — instalacja plików kita z poziomu serwera MCP.
+
+Suita odpala **prawdziwy** ``scripts/bootstrap-project.sh`` (na kopii w katalogu
+tymczasowym), bo cała wartość tego narzędzia polega na tym, że skrypt zostaje
+jedynym źródłem prawdy o rozkładzie plików. Bez basha: skip lokalnie, błąd na CI —
+ta sama polityka co w `test_shell_suites`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from test_bash_hook_launcher import is_ci, resolve_bash
+
+from guides import server
+from guides.bootstrap import BootstrapError, find_bash, plan_bootstrap, run_bootstrap
+
+KIT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _snapshot(root: Path) -> dict[str, bytes]:
+    """Zawartość wszystkich plików pod ``root`` — do porównania „nic nie ruszono”."""
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in root.rglob("*")
+        if path.is_file()
+    }
+
+
+class _BootstrapTestCase(unittest.TestCase):
+    """Wspólny strażnik dostępności basha."""
+
+    def setUp(self) -> None:
+        if not resolve_bash():
+            if is_ci():
+                self.fail("brak bash w środowisku CI — bootstrap musi się wykonać")
+            self.skipTest("brak bash / Git for Windows w PATH")
+
+
+class TestFindBash(_BootstrapTestCase):
+    def test_find_bash_points_at_existing_interpreter(self) -> None:
+        """Na Windows to ma być konkretny bash.exe, nie samo słowo `bash`."""
+        bash = find_bash()
+        self.assertTrue(bash)
+        if bash != "bash":
+            self.assertTrue(Path(bash).is_file())
+
+
+class TestDryRun(_BootstrapTestCase):
+    def test_dry_run_does_not_touch_workspace(self) -> None:
+        """Plan powstaje z przebiegu w sandboxie — repo aplikacji zostaje nietknięte."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+            (workspace / "README.md").write_text("app\n", encoding="utf-8")
+
+            before = _snapshot(workspace)
+            plan = plan_bootstrap(
+                workspace_root=workspace,
+                kit_root=KIT_ROOT,
+                clients="claude",
+            )
+            self.assertEqual(_snapshot(workspace), before)
+
+            self.assertIn(".claude/hooks/gate-destructive.sh", plan.created)
+            self.assertIn(".claude/settings.json", plan.created)
+            self.assertIn(".ai/.kit-bootstrap.json", plan.created)
+            self.assertEqual(plan.modified, [])
+            self.assertEqual(plan.deleted, [])
+
+    def test_dry_run_reports_deletions_from_client_pruning(self) -> None:
+        """Sprzątanie klientów spoza --clients też widać w planie, zanim skasuje."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            (workspace / ".cursor" / "hooks").mkdir(parents=True)
+            (workspace / ".cursor" / "mcp.json").write_text("{}\n", encoding="utf-8")
+
+            before = _snapshot(workspace)
+            plan = plan_bootstrap(
+                workspace_root=workspace,
+                kit_root=KIT_ROOT,
+                clients="claude",
+            )
+            self.assertEqual(_snapshot(workspace), before)
+            self.assertIn(".cursor/mcp.json", plan.deleted)
+
+
+class TestRealRun(_BootstrapTestCase):
+    def test_run_installs_hooks_settings_and_stamp(self) -> None:
+        """Kryterium ukończenia z issue #31 — hooki, PreToolUse i stamp na dysku."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+
+            run_bootstrap(target=workspace, kit_root=KIT_ROOT, clients="claude")
+
+            self.assertTrue((workspace / ".claude" / "hooks" / "gate-destructive.sh").is_file())
+            self.assertTrue((workspace / ".ai" / ".kit-bootstrap.json").is_file())
+            settings = (workspace / ".claude" / "settings.json").read_text(encoding="utf-8")
+            self.assertIn("PreToolUse", settings)
+
+    def test_missing_script_is_an_error(self) -> None:
+        """Kit bez skryptu bootstrapu — jasny błąd zamiast cichego nic."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_kit = Path(tmp) / "kit"
+            fake_kit.mkdir()
+            with self.assertRaises(BootstrapError) as ctx:
+                run_bootstrap(target=Path(tmp) / "app", kit_root=fake_kit)
+            self.assertIn("bootstrap-project.sh", str(ctx.exception))
+
+
+class TestServerTool(_BootstrapTestCase):
+    """Narzędzie MCP — domyślki, bramka dry-run i odmowy."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved = (
+            server._profile_path,
+            server._kit_root,
+            server._workspace_root,
+            server._clients,
+            server._preset,
+        )
+        server._profile_path = KIT_ROOT / "profiles" / "_base.yaml"
+        server._kit_root = KIT_ROOT
+        server._clients = ["claude"]
+        server._preset = "_base"
+        self._tmp = tempfile.mkdtemp(prefix="guides-tool-test-")
+        self.addCleanup(shutil.rmtree, self._tmp, True)
+        self.workspace = Path(self._tmp) / "app"
+        self.workspace.mkdir()
+        server._workspace_root = self.workspace
+
+    def tearDown(self) -> None:
+        (
+            server._profile_path,
+            server._kit_root,
+            server._workspace_root,
+            server._clients,
+            server._preset,
+        ) = self._saved
+
+    def test_default_call_is_dry_run(self) -> None:
+        """Bez argumentów narzędzie planuje, nie instaluje."""
+        before = _snapshot(self.workspace)
+        out = server.bootstrap_workspace()
+        self.assertIn("dry run", out)
+        self.assertIn(".ai/.kit-bootstrap.json", out)
+        self.assertEqual(_snapshot(self.workspace), before)
+
+    def test_explicit_dry_run_false_installs(self) -> None:
+        """Zapis wymaga jawnego dry_run=False."""
+        out = server.bootstrap_workspace(dry_run=False)
+        self.assertIn("zainstalowano", out)
+        self.assertTrue((self.workspace / ".ai" / ".kit-bootstrap.json").is_file())
+        self.assertTrue((self.workspace / ".claude" / "hooks" / "gate-destructive.sh").is_file())
+
+    def test_missing_workspace_errors_instead_of_writing_cwd(self) -> None:
+        """Brak --workspace: błąd, a bieżący katalog procesu zostaje nietknięty."""
+        server._workspace_root = None
+        cwd_sentinel = Path(self._tmp) / "cwd"
+        cwd_sentinel.mkdir()
+        previous = Path.cwd()
+        os.chdir(cwd_sentinel)
+        self.addCleanup(os.chdir, previous)
+
+        out = server.bootstrap_workspace(dry_run=False)
+
+        self.assertIn("błąd", out)
+        self.assertIn("--workspace", out)
+        self.assertEqual(_snapshot(cwd_sentinel), {})
+
+    def test_workspace_equal_to_kit_is_refused(self) -> None:
+        """Bootstrap repo kita samym sobą to pomyłka, nie funkcja."""
+        server._workspace_root = KIT_ROOT
+        out = server.bootstrap_workspace(dry_run=False)
+        self.assertIn("błąd", out)
+        self.assertIn("ten sam katalog", out)
+
+    def test_invalid_clients_is_reported_not_raised(self) -> None:
+        """Zła wartość --clients wraca jako komunikat narzędzia."""
+        out = server.bootstrap_workspace(clients="nieistniejacy-klient")
+        self.assertIn("błąd", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #31

## Problem

Podłączenie serwera MCP `project-guides` wyglądało jak instalacja kita, a bramek nie dawało. Wszystkie narzędzia w `src/guides/server.py` były wyłącznie odczytowe, więc żeby dostać hooki `PreToolUse`, agentów i komendy, użytkownik musiał sklonować kit lokalnie tylko po to, by odpalić jeden skrypt — mimo że serwer MCP ma już wszystkie szablony pod ręką. Flaga `--clients` pogłębiała pomyłkę: w serwerze jest sama metadaną, a w `bootstrap-project.sh` faktycznie kopiuje pliki klienta.

## Rozwiązanie

Nowe narzędzie MCP `bootstrap_workspace(clients, preset, language, codegen, with_overlay, keep_unselected_clients, dry_run=True)` uruchamia **ten sam** `scripts/bootstrap-project.sh` z `kit_root` na `_workspace_root`. Skrypt zostaje jedynym źródłem prawdy o tym, co gdzie ląduje — Python go nie przepisuje.

- `src/guides/bootstrap.py` — warstwa wykonawcza: wyszukanie basha (na Windows Git Bash, ta sama kolejność kandydatów co `templates/shared/guards/invoke-hook.js`), budowa argv, uruchomienie, plan dry-runu.
- `src/guides/server.py` — narzędzie, domyślki z parametrów startowych serwera, odmowy.
- `src/guides/kit_status.py` — `check_kit_status` wskazuje teraz to narzędzie, nie tylko instrukcję ręcznego uruchomienia skryptu.

### Dry-run bez drugiej listy ścieżek

Zamiast symulować skrypt w Pythonie (co natychmiast by się rozjechało z bashem), dry-run kopiuje kitową powierzchnię repo (`KIT_SURFACE`) do katalogu tymczasowego, odpala tam **prawdziwy** bootstrap i porównuje wynik z oryginałem. Dzięki temu plan:

- zna pliki, które sprzątanie klientów spoza `--clients` by **usunęło**,
- zachowuje semantykę „nie nadpisuj jeśli istnieje" (`AGENTS.md`, `BUGBOT.md`, `.ai/project.md`),
- przechodzi przez faktyczne scalanie `.claude/settings.json`.

### Bramki

Zapis przez MCP omija hooki kita — łapią `Bash`, `PowerShell` i `Edit|Write|MultiEdit|NotebookEdit`, a nie nazwy narzędzi MCP. Zgodnie z założeniem domyślnym z issue: `dry_run=True` jest domyślką, zapis wymaga jawnego `dry_run=False`. Dodatkowo brak `--workspace` kończy się błędem zamiast zapisem w cwd procesu serwera, a workspace równy `kit_root` jest odrzucany. Reszta narzędzi serwera pozostaje tylko do odczytu.

## Testy

`tests/test_bootstrap.py` — 10 testów, odpalają prawdziwy skrypt na katalogach tymczasowych. Bez basha: skip lokalnie, błąd na CI (ta sama polityka co `test_shell_suites`).

- dry-run nie dotyka repo (snapshot przed/po) i wymienia hooki, `settings.json` oraz stamp,
- dry-run raportuje usunięcia ze sprzątania klientów,
- właściwe wywołanie zakłada `gate-destructive.sh`, `PreToolUse` i stamp,
- brak `--workspace` → błąd, cwd nietknięte,
- workspace == kit → odmowa; zła wartość `clients` → komunikat, nie wyjątek,
- kit bez skryptu → jasny błąd.

Ręczne kryterium z issue odegrane end-to-end na czystym repo: `check_kit_status` przed → „brak stampu" (ze wskazaniem narzędzia); dry run → lista plików, na dysku zostaje tylko `README.md`; `dry_run=False` → hooki, `PreToolUse`, stamp; `check_kit_status` po → „aktualny".

```
uv run python -m unittest discover -s tests -p "test_bootstrap.py"   # 10 OK
uv tool run ty check                                                  # All checks passed!
```

Pełna suita: 84 testy, jedna awaria — `test_shell_suites` przekroczył 300 s na `test_gate_destructive.sh` (znany #24, zamulenie środowiska na Windows). Ten branch nie rusza skryptów guard.

## Poza zakresem

Przepisanie `bootstrap-project.sh` na Pythona, automatyczny bootstrap przy starcie serwera, matcher na nazwy narzędzi MCP w szablonie hooków.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UctHLZb96FHZ1PrUpKi92t
