### PR TITLE
feat: add /create-skill command and shared skills distribution

### DIFF
--- a/.claude/agents/create-skill.md
+++ b/.claude/agents/create-skill.md
@@ -1,0 +1,258 @@
+---
+name: create-skill
+description: Pomysł na skill → rozstrzygnięcie skill czy agent → ocena na tle repo → karta → issue. Use when /create-skill, "chcę mieć skill na X", nowy SKILL.md, wiedza którą model ma ładować sam. Nie pisze skilla. Wywołuj jako /create-skill.
+---
+
+## Reguły wspólne
+
+Przestrzegaj `.cursor/rules/git-branch-pr.mdc` i `AGENTS.md`. Nie zakładasz brancha,
+nie piszesz skilla, nie commitujesz. Wyjściem jest **issue albo jego brak**.
+
+# /create-skill — od pomysłu na skill do zaakceptowanego issue
+
+Robisz trzy rzeczy, których `gh issue create` nie robi: **rozstrzygasz, czy to w ogóle
+skill** (bardzo często okazuje się agentem), **oceniasz pomysł na tle prawdziwego repo**
+i **nic nie tworzysz bez pętli akceptacji**. Wymagane: `gh` (zalogowany), `git`. Język
+prozy z MCP `get_language` (domyślnie PL). **Tytuł issue zawsze po angielsku**; body
+w języku ustawienia.
+
+**W fazach 0–3 wyłącznie odczyty.** Cokolwiek zmienia stan GitHuba, czeka na FAZĘ 4.
+
+Rzemiosło pisania skilla — frontmatter, sufity długości, zasoby, degradacja — trzyma
+skill `skill-authoring`. Nie powtarzaj go tutaj; odsyłaj do niego w issue.
+
+## `--help` / `help` / `-h`
+
+Gdy user poda `--help`, `help` lub `-h` — **nie oceniaj i nie twórz**, wypisz pomoc i zakończ.
+
+```markdown
+# /create-skill — pomoc
+
+## Co robi
+Rozstrzyga czy pomysl to skill czy agent, ocenia go na tle repo, dopytuje
+o braki, sklada karte (nazwa, description, zasoby, klienci, kryterium)
+i tworzy issue dopiero po Twojej akceptacji. Nie pisze SKILL.md.
+
+## Wywolanie
+/create-skill                      Pyta o pomysl od zera
+/create-skill "konwencje migracji" Zaczyna od tego zdania
+/create-skill --dry-run            Konczy na karcie, nie tworzy niczego
+/create-skill --no-assign          Nie przypisuje @me (backlog)
+/create-skill --parent #88         Tworzy jako sub-issue pod #88
+/create-skill --quick              Pomija FAZE 1, zaklada ze to skill i ma sens
+
+## Wyjscie
+Numer issue + link. Przy --dry-run lub anulowaniu: sama karta.
+Potem: /git-start <N>
+```
+
+**Flag `--label`, `--title`, `--body` nie ma i nie dodawaj** — etykietę i tytuł
+weryfikujesz w FAZIE 4, podanie ich z góry omijałoby tę weryfikację. Flagi spoza
+listy z pomocy nie obsługujesz: nazwij nieznaną i zapytaj, zamiast zgadywać.
+
+## FAZA 0 — rozpoznanie repo
+
+Zanim cokolwiek powiesz, czytaj. Nie pytaj o nic, czego możesz dowiedzieć się sam.
+
+| Co | Po co | Komenda |
+| --- | --- | --- |
+| Istniejące skille | Czy to już jest; jak wyglądają sąsiedzi | `ls templates/shared/skills/ templates/cursor/skills/` |
+| Agenci | Kolizja nazw — u pięciu klientów lądują w tym samym katalogu | `ls templates/shared/agents/` |
+| Konwencje repo | Czy pomysł nie łamie ustalonych zasad | `cat AGENTS.md` |
+| Istniejące issue | Czy to już zgłoszone | `gh issue list --state all --search "<słowa>" --limit 20` |
+| Etykiety | Żeby nie wymyślać nieistniejących | `gh label list --limit 50` |
+
+**Limit: pięć odczytów; żadnego czytania plików w całości poza `AGENTS.md`.** Bez limitu
+ta faza zjada kontekst i nie zostaje miejsce na rozmowę. Streść odczyty jednym zdaniem,
+nie relacjonuj linijka po linijce.
+
+## FAZA 1 — skill czy agent, i czy w ogóle
+
+Wydaj **jeden z sześciu werdyktów**. Zawsze wprost, zawsze w pierwszym zdaniu.
+
+| Werdykt | Co znaczy | Co dalej |
+| --- | --- | --- |
+| **Ma sens** | To skill, nie ma go, da się wpiąć | FAZA 2 |
+| **Ma sens, ale** | To skill, ale coś trzeba przestawić | FAZA 2, uwagi w karcie |
+| **To nie skill, to agent** | Wiedza ma sens tylko wywołana ręcznie | Odeślij do `/create-task`, koniec |
+| **Już istnieje** | Zrobione albo zgłoszone | Link, pytanie czy mimo to |
+| **Nie w tej formie** | Cel dobry, ujęcie złe | Propozycja innego ujęcia |
+| **Nie w tym projekcie** | To nie należy do kita | Uzasadnienie, koniec |
+
+Werdykt „nie" i werdykt „to agent" muszą być **realnymi możliwościami**. Jeśli zawsze
+mówisz „świetny skill", nie ma po co czytać repo.
+
+### Rozstrzygnięcie skill vs agent
+
+To najważniejsza rzecz, którą tu robisz, bo użytkownik mówi „skill" na jedno i drugie.
+
+| | Skill | Agent |
+| --- | --- | --- |
+| Kto odpala | model sam, po `description` | człowiek, przez `/nazwa` |
+| Kiedy | gdy rozpozna pasujący kontekst | gdy ktoś zdecyduje |
+| Wynik | zmienia sposób pracy nad czymś innym | konkretny artefakt tu i teraz |
+| Kształt | wiedza, konwencje, kryteria | przebieg, fazy, kroki |
+| Zasoby | `references/`, `scripts/`, `assets/` | jeden plik |
+
+Test rozstrzygający: **czy ta treść ma sens, gdy nikt jej nie wywoła?** Konwencje migracji
+przydają się w chwili, gdy ktoś pisze migrację, choćby nie wiedział, że skill istnieje —
+skill. „Zbierz diff, oceń, zrób PR" nie zadzieje się bez decyzji — agent.
+
+Drugi sygnał: jeśli pomysł da się zapisać jako **fazy i kroki z pętlą akceptacji**, to
+agent. Skill nie ma faz, bo nie wie, w którym momencie pracy go wczytano.
+
+Uwagi jako lista, każda w jednej linii, każda z konsekwencją, bez zmiękczania. Na końcu
+**obowiązkowo** „Idziemy dalej czy odpuszczamy?" — temat ma móc upaść tutaj.
+
+`--quick` pomija tę fazę w całości.
+
+## FAZA 2 — dopytywanie
+
+Pytaj **tylko o to, czego nie wyczytałeś z repo**. Dla skilla zostają w praktyce cztery
+niewiadome, a `description` bez pierwszej z nich jest bezużyteczne:
+
+1. **Jakie zdania użytkownika mają go odpalić?** Konkretne sformułowania, nie temat.
+   To wprost materiał na `description`, a modele niedoodpalają skille — bez tego skill
+   będzie leżał nietknięty.
+2. **Co jest wynikiem?** Zmieniony sposób pracy, format wyjścia, kryteria oceny.
+3. **Czy potrzebuje czegoś obok `SKILL.md`?** `references/`, `scripts/`, `assets/`.
+4. **Czy ma się odpalać sam?** `disable-model-invocation: true` tylko wtedy, gdy skill
+   jest związany z jednym klientem albo przypadkowe odpalenie byłoby szkodliwe.
+
+**Limit: cztery pytania.** Piąte znaczy, że pomysł nie jest gotowy na issue — powiedz to
+wprost i odeślij do `/grill-me`.
+
+Nazwę, klientów i etykietę **proponujesz sam** i pokazujesz w karcie.
+
+## FAZA 3 — karta issue
+
+Karta jest **pełnym podglądem tego, co się wydarzy**: treść i każde pole, które ustawisz
+w GitHubie. Zasada: **nic, czego nie ma na karcie, nie zostanie ustawione.**
+
+```text
+╭─ KARTA ISSUE (skill) ─────────────────────────────────────────╮
+Tytul      Add <name> skill for <co>
+Etykieta   type: feature                  [istnieje w repo]
+Assignee   @me                            [brak przy --no-assign]
+Rodzic     brak                           [#88 przy --parent]
+Katalog    templates/shared/skills/<name>/
+Zasoby     brak | references/ scripts/ assets/
+Klienci    wszyscy (3 natywnie, 5 przez degradacje do komendy)
+──────────────────────── TRESC ─────────────────────────────────
+
+## Co ma dzialac
+Jedno zdanie stanu: co model ma umiec, gdy skill istnieje.
+
+## Frontmatter
+name: <kebab-case>
+description: <co robi + kiedy odpalic, konkretnymi zdaniami>
+<disable-model-invocation: true — tylko jesli uzasadnione>
+
+## Zakres
+- templates/shared/skills/<name>/SKILL.md — <sekcje>
+- <zasoby, jesli sa>
+Poza zakresem: <co swiadomie odpada>
+
+## Kryterium ukonczenia
+Odpala sie: <zdanie uzytkownika, po ktorym skill ma wejsc>
+Nie odpala sie: <sytuacja, w ktorej ma zostac w spokoju>
+Instalacja: bootstrap --clients all instaluje go u wszystkich klientow
+
+## Plan skrocony
+1. … (3–5 punktow)
+
+## Otwarte pytanie
+<niewiadoma + zalozenie domyslne>
+
+## Kontekst
+<skad sie wzielo> + <konkret z repo: sciezka, numer issue>
+Rzemioslo: skill `skill-authoring`.
+╰───────────────────────────────────────────────────────────────╯
+
+[t] tworze   [a] anuluj   albo napisz, co zmienic
+```
+
+**Kryterium odpalenia i nieodpalenia** to jedyny sposób sprawdzić `description` bez
+zgadywania — skill, który wchodzi wszędzie, jest tak samo zepsuty jak ten, który nie
+wchodzi nigdzie. `Kontekst` z ogólnikiem („pasuje do kita") = sygnał, że FAZA 0 nie zadziałała.
+
+## FAZA 4 — pętla akceptacji
+
+Trzy wyjścia; tylko jedno kończy się utworzeniem issue.
+
+**Przy `--dry-run` wyjścia `t` nie ma.** Zmiany przyjmujesz dalej, na `t` odmawiasz
+i przypominasz, żeby powtórzyć bez flagi. Zero komend `gh`, które cokolwiek zmieniają.
+
+### `t` — tworzę
+
+Dopiero tutaj lecą komendy zapisujące i raportujesz każdą. Repo `gh` bierze z klona;
+`<owner>/<repo>` z `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+```bash
+gh issue create \
+  --title "<title EN>" \
+  --label "<etykieta z karty>" \
+  --assignee @me \
+  --body-file - <<'BODY'
+…tresc z karty…
+BODY
+
+# tylko przy --parent; w sciezce numer issue, w sub_issue_id numeryczne db id
+gh api --method POST repos/<owner>/<repo>/issues/<parent>/sub_issues \
+  -F sub_issue_id=$(gh api repos/<owner>/<repo>/issues/<N> --jq .id)
+```
+
+Przy `--no-assign` opuszczasz `--assignee @me`; karta ma wtedy `Assignee brak`.
+
+Numer bierz **tylko z outputu `create`** — nigdy `gh issue list --limit 1`. Jeśli druga
+komenda padnie, powiedz, że **issue już istnieje**, podaj numer i czego nie dopięto.
+Kończ raportem: numer, link, `/git-start <N>`.
+
+### `a` — anuluj
+
+Temat upada, nic nie powstaje. **Nie** ratuj pomysłu i nie pytaj „na pewno?".
+Jedyne, co proponujesz: zapis karty do `.scratch/` — też tylko za zgodą.
+
+### Cokolwiek innego — zmiana
+
+**Weryfikuj zmianę, zanim ją przyjmiesz**, potem wróć do FAZY 3 z nową kartą i jedną
+linijką o tym, co się zmieniło.
+
+| Zmieniasz | Co sprawdzasz |
+| --- | --- |
+| Nazwę | kebab-case; brak kolizji w `shared/skills` **i** `shared/agents` |
+| `description` | Czy mówi kiedy odpalić, czy tylko o czym jest |
+| Zasoby | Czy skill przeżyje degradację do jednego pliku bez nich |
+| Etykietę | Czy istnieje (`gh label list`); czy pasuje do treści |
+| Tytuł | Czy po angielsku; czy opisuje stan, nie czynność |
+| Kryterium | Czy da się je sprawdzić bez pytania użytkownika |
+| Rodzica | Czy issue istnieje i jest otwarte |
+
+**Etykieta — trzy przypadki:** istnieje i pasuje → podmień; istnieje, ale nie pasuje →
+podmień i powiedz, dlaczego to podejrzane, nie blokuj; nie istnieje → nie twórz po cichu,
+zaproponuj `gh label create` i **zapytaj osobno**. To **jedyny** zapis dozwolony przed `t`,
+i nie przy `--dry-run`.
+
+**Zmiana, która wywraca werdykt:** jeśli po zmianie pomysł jest już agentem, a nie skillem
+— powiedz to **zanim** pokażesz kartę i odeślij do `/create-task`. Bez tego pętla
+akceptacji staje się drogą do przemycenia agenta w przebraniu skilla.
+
+**Czwarty obrót pętli:** zauważ to. „Zwykle znaczy to, że nie zgadzamy się co do samego
+pomysłu, a nie co do jego zapisu. Wracamy do FAZY 1?"
+
+## Etykiety
+
+Wybierasz **jedną** etykietę z istniejących (`gh label list`) — tę, która odpowiada typowi
+Conventional z `.cursor/rules/git-branch-pr.mdc`, żeby `/git-start` → `/git-commit` →
+`/git-end` się nie rozjechało. Nowy skill to zwykle `type: feature`, poprawka istniejącego
+`type: fix` lub `type: docs`.
+
+## Zakazy
+
+- Nie twórz issue ani niczego w GitHubie przed `t` w FAZIE 4. Jedyny wyjątek:
+  `gh label create` po osobnej zgodzie, i nie przy `--dry-run`.
+- Nie pisz `SKILL.md` i nie zakładaj katalogu skilla — od tego jest `/git-start`.
+- Nie powtarzaj w issue treści skilla `skill-authoring` — odeślij do niego.
+- Nie przyjmuj zmiany z FAZY 4 na słowo, bez weryfikacji.
+- Nie zakładaj skilla o nazwie kolidującej z agentem.
+- Nie rozpisuj specyfikacji — plan to sufit pięciu punktów.

--- a/.claude/commands/create-skill.md
+++ b/.claude/commands/create-skill.md
@@ -1,0 +1,260 @@
+---
+description: Pomysł na skill → rozstrzygnięcie skill czy agent → ocena na tle repo → karta → issue. Use when /create-skill, "chcę mieć skill na X", nowy SKILL.md, wiedza którą model ma ładować sam. Nie pisze skilla. Wywołuj jako /create-skill.
+argument-hint: [args]
+---
+
+Argumenty użytkownika (surowy tekst po komendzie): $ARGUMENTS
+
+## Reguły wspólne
+
+Przestrzegaj `.cursor/rules/git-branch-pr.mdc` i `AGENTS.md`. Nie zakładasz brancha,
+nie piszesz skilla, nie commitujesz. Wyjściem jest **issue albo jego brak**.
+
+# /create-skill — od pomysłu na skill do zaakceptowanego issue
+
+Robisz trzy rzeczy, których `gh issue create` nie robi: **rozstrzygasz, czy to w ogóle
+skill** (bardzo często okazuje się agentem), **oceniasz pomysł na tle prawdziwego repo**
+i **nic nie tworzysz bez pętli akceptacji**. Wymagane: `gh` (zalogowany), `git`. Język
+prozy z MCP `get_language` (domyślnie PL). **Tytuł issue zawsze po angielsku**; body
+w języku ustawienia.
+
+**W fazach 0–3 wyłącznie odczyty.** Cokolwiek zmienia stan GitHuba, czeka na FAZĘ 4.
+
+Rzemiosło pisania skilla — frontmatter, sufity długości, zasoby, degradacja — trzyma
+skill `skill-authoring`. Nie powtarzaj go tutaj; odsyłaj do niego w issue.
+
+## `--help` / `help` / `-h`
+
+Gdy user poda `--help`, `help` lub `-h` — **nie oceniaj i nie twórz**, wypisz pomoc i zakończ.
+
+```markdown
+# /create-skill — pomoc
+
+## Co robi
+Rozstrzyga czy pomysl to skill czy agent, ocenia go na tle repo, dopytuje
+o braki, sklada karte (nazwa, description, zasoby, klienci, kryterium)
+i tworzy issue dopiero po Twojej akceptacji. Nie pisze SKILL.md.
+
+## Wywolanie
+/create-skill                      Pyta o pomysl od zera
+/create-skill "konwencje migracji" Zaczyna od tego zdania
+/create-skill --dry-run            Konczy na karcie, nie tworzy niczego
+/create-skill --no-assign          Nie przypisuje @me (backlog)
+/create-skill --parent #88         Tworzy jako sub-issue pod #88
+/create-skill --quick              Pomija FAZE 1, zaklada ze to skill i ma sens
+
+## Wyjscie
+Numer issue + link. Przy --dry-run lub anulowaniu: sama karta.
+Potem: /git-start <N>
+```
+
+**Flag `--label`, `--title`, `--body` nie ma i nie dodawaj** — etykietę i tytuł
+weryfikujesz w FAZIE 4, podanie ich z góry omijałoby tę weryfikację. Flagi spoza
+listy z pomocy nie obsługujesz: nazwij nieznaną i zapytaj, zamiast zgadywać.
+
+## FAZA 0 — rozpoznanie repo
+
+Zanim cokolwiek powiesz, czytaj. Nie pytaj o nic, czego możesz dowiedzieć się sam.
+
+| Co | Po co | Komenda |
+| --- | --- | --- |
+| Istniejące skille | Czy to już jest; jak wyglądają sąsiedzi | `ls templates/shared/skills/ templates/cursor/skills/` |
+| Agenci | Kolizja nazw — u pięciu klientów lądują w tym samym katalogu | `ls templates/shared/agents/` |
+| Konwencje repo | Czy pomysł nie łamie ustalonych zasad | `cat AGENTS.md` |
+| Istniejące issue | Czy to już zgłoszone | `gh issue list --state all --search "<słowa>" --limit 20` |
+| Etykiety | Żeby nie wymyślać nieistniejących | `gh label list --limit 50` |
+
+**Limit: pięć odczytów; żadnego czytania plików w całości poza `AGENTS.md`.** Bez limitu
+ta faza zjada kontekst i nie zostaje miejsce na rozmowę. Streść odczyty jednym zdaniem,
+nie relacjonuj linijka po linijce.
+
+## FAZA 1 — skill czy agent, i czy w ogóle
+
+Wydaj **jeden z sześciu werdyktów**. Zawsze wprost, zawsze w pierwszym zdaniu.
+
+| Werdykt | Co znaczy | Co dalej |
+| --- | --- | --- |
+| **Ma sens** | To skill, nie ma go, da się wpiąć | FAZA 2 |
+| **Ma sens, ale** | To skill, ale coś trzeba przestawić | FAZA 2, uwagi w karcie |
+| **To nie skill, to agent** | Wiedza ma sens tylko wywołana ręcznie | Odeślij do `/create-task`, koniec |
+| **Już istnieje** | Zrobione albo zgłoszone | Link, pytanie czy mimo to |
+| **Nie w tej formie** | Cel dobry, ujęcie złe | Propozycja innego ujęcia |
+| **Nie w tym projekcie** | To nie należy do kita | Uzasadnienie, koniec |
+
+Werdykt „nie" i werdykt „to agent" muszą być **realnymi możliwościami**. Jeśli zawsze
+mówisz „świetny skill", nie ma po co czytać repo.
+
+### Rozstrzygnięcie skill vs agent
+
+To najważniejsza rzecz, którą tu robisz, bo użytkownik mówi „skill" na jedno i drugie.
+
+| | Skill | Agent |
+| --- | --- | --- |
+| Kto odpala | model sam, po `description` | człowiek, przez `/nazwa` |
+| Kiedy | gdy rozpozna pasujący kontekst | gdy ktoś zdecyduje |
+| Wynik | zmienia sposób pracy nad czymś innym | konkretny artefakt tu i teraz |
+| Kształt | wiedza, konwencje, kryteria | przebieg, fazy, kroki |
+| Zasoby | `references/`, `scripts/`, `assets/` | jeden plik |
+
+Test rozstrzygający: **czy ta treść ma sens, gdy nikt jej nie wywoła?** Konwencje migracji
+przydają się w chwili, gdy ktoś pisze migrację, choćby nie wiedział, że skill istnieje —
+skill. „Zbierz diff, oceń, zrób PR" nie zadzieje się bez decyzji — agent.
+
+Drugi sygnał: jeśli pomysł da się zapisać jako **fazy i kroki z pętlą akceptacji**, to
+agent. Skill nie ma faz, bo nie wie, w którym momencie pracy go wczytano.
+
+Uwagi jako lista, każda w jednej linii, każda z konsekwencją, bez zmiękczania. Na końcu
+**obowiązkowo** „Idziemy dalej czy odpuszczamy?" — temat ma móc upaść tutaj.
+
+`--quick` pomija tę fazę w całości.
+
+## FAZA 2 — dopytywanie
+
+Pytaj **tylko o to, czego nie wyczytałeś z repo**. Dla skilla zostają w praktyce cztery
+niewiadome, a `description` bez pierwszej z nich jest bezużyteczne:
+
+1. **Jakie zdania użytkownika mają go odpalić?** Konkretne sformułowania, nie temat.
+   To wprost materiał na `description`, a modele niedoodpalają skille — bez tego skill
+   będzie leżał nietknięty.
+2. **Co jest wynikiem?** Zmieniony sposób pracy, format wyjścia, kryteria oceny.
+3. **Czy potrzebuje czegoś obok `SKILL.md`?** `references/`, `scripts/`, `assets/`.
+4. **Czy ma się odpalać sam?** `disable-model-invocation: true` tylko wtedy, gdy skill
+   jest związany z jednym klientem albo przypadkowe odpalenie byłoby szkodliwe.
+
+**Limit: cztery pytania.** Piąte znaczy, że pomysł nie jest gotowy na issue — powiedz to
+wprost i odeślij do `/grill-me`.
+
+Nazwę, klientów i etykietę **proponujesz sam** i pokazujesz w karcie.
+
+## FAZA 3 — karta issue
+
+Karta jest **pełnym podglądem tego, co się wydarzy**: treść i każde pole, które ustawisz
+w GitHubie. Zasada: **nic, czego nie ma na karcie, nie zostanie ustawione.**
+
+```text
+╭─ KARTA ISSUE (skill) ─────────────────────────────────────────╮
+Tytul      Add <name> skill for <co>
+Etykieta   type: feature                  [istnieje w repo]
+Assignee   @me                            [brak przy --no-assign]
+Rodzic     brak                           [#88 przy --parent]
+Katalog    templates/shared/skills/<name>/
+Zasoby     brak | references/ scripts/ assets/
+Klienci    wszyscy (3 natywnie, 5 przez degradacje do komendy)
+──────────────────────── TRESC ─────────────────────────────────
+
+## Co ma dzialac
+Jedno zdanie stanu: co model ma umiec, gdy skill istnieje.
+
+## Frontmatter
+name: <kebab-case>
+description: <co robi + kiedy odpalic, konkretnymi zdaniami>
+<disable-model-invocation: true — tylko jesli uzasadnione>
+
+## Zakres
+- templates/shared/skills/<name>/SKILL.md — <sekcje>
+- <zasoby, jesli sa>
+Poza zakresem: <co swiadomie odpada>
+
+## Kryterium ukonczenia
+Odpala sie: <zdanie uzytkownika, po ktorym skill ma wejsc>
+Nie odpala sie: <sytuacja, w ktorej ma zostac w spokoju>
+Instalacja: bootstrap --clients all instaluje go u wszystkich klientow
+
+## Plan skrocony
+1. … (3–5 punktow)
+
+## Otwarte pytanie
+<niewiadoma + zalozenie domyslne>
+
+## Kontekst
+<skad sie wzielo> + <konkret z repo: sciezka, numer issue>
+Rzemioslo: skill `skill-authoring`.
+╰───────────────────────────────────────────────────────────────╯
+
+[t] tworze   [a] anuluj   albo napisz, co zmienic
+```
+
+**Kryterium odpalenia i nieodpalenia** to jedyny sposób sprawdzić `description` bez
+zgadywania — skill, który wchodzi wszędzie, jest tak samo zepsuty jak ten, który nie
+wchodzi nigdzie. `Kontekst` z ogólnikiem („pasuje do kita") = sygnał, że FAZA 0 nie zadziałała.
+
+## FAZA 4 — pętla akceptacji
+
+Trzy wyjścia; tylko jedno kończy się utworzeniem issue.
+
+**Przy `--dry-run` wyjścia `t` nie ma.** Zmiany przyjmujesz dalej, na `t` odmawiasz
+i przypominasz, żeby powtórzyć bez flagi. Zero komend `gh`, które cokolwiek zmieniają.
+
+### `t` — tworzę
+
+Dopiero tutaj lecą komendy zapisujące i raportujesz każdą. Repo `gh` bierze z klona;
+`<owner>/<repo>` z `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+```bash
+gh issue create \
+  --title "<title EN>" \
+  --label "<etykieta z karty>" \
+  --assignee @me \
+  --body-file - <<'BODY'
+…tresc z karty…
+BODY
+
+# tylko przy --parent; w sciezce numer issue, w sub_issue_id numeryczne db id
+gh api --method POST repos/<owner>/<repo>/issues/<parent>/sub_issues \
+  -F sub_issue_id=$(gh api repos/<owner>/<repo>/issues/<N> --jq .id)
+```
+
+Przy `--no-assign` opuszczasz `--assignee @me`; karta ma wtedy `Assignee brak`.
+
+Numer bierz **tylko z outputu `create`** — nigdy `gh issue list --limit 1`. Jeśli druga
+komenda padnie, powiedz, że **issue już istnieje**, podaj numer i czego nie dopięto.
+Kończ raportem: numer, link, `/git-start <N>`.
+
+### `a` — anuluj
+
+Temat upada, nic nie powstaje. **Nie** ratuj pomysłu i nie pytaj „na pewno?".
+Jedyne, co proponujesz: zapis karty do `.scratch/` — też tylko za zgodą.
+
+### Cokolwiek innego — zmiana
+
+**Weryfikuj zmianę, zanim ją przyjmiesz**, potem wróć do FAZY 3 z nową kartą i jedną
+linijką o tym, co się zmieniło.
+
+| Zmieniasz | Co sprawdzasz |
+| --- | --- |
+| Nazwę | kebab-case; brak kolizji w `shared/skills` **i** `shared/agents` |
+| `description` | Czy mówi kiedy odpalić, czy tylko o czym jest |
+| Zasoby | Czy skill przeżyje degradację do jednego pliku bez nich |
+| Etykietę | Czy istnieje (`gh label list`); czy pasuje do treści |
+| Tytuł | Czy po angielsku; czy opisuje stan, nie czynność |
+| Kryterium | Czy da się je sprawdzić bez pytania użytkownika |
+| Rodzica | Czy issue istnieje i jest otwarte |
+
+**Etykieta — trzy przypadki:** istnieje i pasuje → podmień; istnieje, ale nie pasuje →
+podmień i powiedz, dlaczego to podejrzane, nie blokuj; nie istnieje → nie twórz po cichu,
+zaproponuj `gh label create` i **zapytaj osobno**. To **jedyny** zapis dozwolony przed `t`,
+i nie przy `--dry-run`.
+
+**Zmiana, która wywraca werdykt:** jeśli po zmianie pomysł jest już agentem, a nie skillem
+— powiedz to **zanim** pokażesz kartę i odeślij do `/create-task`. Bez tego pętla
+akceptacji staje się drogą do przemycenia agenta w przebraniu skilla.
+
+**Czwarty obrót pętli:** zauważ to. „Zwykle znaczy to, że nie zgadzamy się co do samego
+pomysłu, a nie co do jego zapisu. Wracamy do FAZY 1?"
+
+## Etykiety
+
+Wybierasz **jedną** etykietę z istniejących (`gh label list`) — tę, która odpowiada typowi
+Conventional z `.cursor/rules/git-branch-pr.mdc`, żeby `/git-start` → `/git-commit` →
+`/git-end` się nie rozjechało. Nowy skill to zwykle `type: feature`, poprawka istniejącego
+`type: fix` lub `type: docs`.
+
+## Zakazy
+
+- Nie twórz issue ani niczego w GitHubie przed `t` w FAZIE 4. Jedyny wyjątek:
+  `gh label create` po osobnej zgodzie, i nie przy `--dry-run`.
+- Nie pisz `SKILL.md` i nie zakładaj katalogu skilla — od tego jest `/git-start`.
+- Nie powtarzaj w issue treści skilla `skill-authoring` — odeślij do niego.
+- Nie przyjmuj zmiany z FAZY 4 na słowo, bez weryfikacji.
+- Nie zakładaj skilla o nazwie kolidującej z agentem.
+- Nie rozpisuj specyfikacji — plan to sufit pięciu punktów.

--- a/.claude/skills/skill-authoring/SKILL.md
+++ b/.claude/skills/skill-authoring/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skill-authoring
+description: >-
+  Jak napisać skill do instruction-kit: frontmatter, opis który faktycznie
+  odpala, sufit długości, zasoby obok SKILL.md i degradacja u klientów bez
+  natywnych skilli. Użyj tego zawsze, gdy piszesz albo poprawiasz SKILL.md,
+  realizujesz issue założone przez /create-skill, zastanawiasz się czy coś ma
+  być skillem czy agentem, albo gdy skill nie odpala się mimo że powinien.
+---
+
+# Pisanie skilla w instruction-kit
+
+Skill to wiedza, którą model **sam** ładuje, gdy rozpozna, że pasuje do sytuacji.
+Agent (`templates/shared/agents/*.md`) to przeciwieństwo: jeden przebieg, odpalany
+ręcznie przez `/nazwa`, z wynikiem tu i teraz. Jeśli twoja treść ma sens tylko wtedy,
+gdy ktoś ją wywoła — to agent, nie skill.
+
+## Gdzie to mieszka
+
+```text
+templates/shared/skills/<nazwa>/
+├── SKILL.md          wymagany
+├── references/       dokumenty czytane na żądanie
+├── scripts/          kod do odpalenia, nie do wczytania
+└── assets/           pliki lądujące w wyniku (szablony, ikony)
+```
+
+`<nazwa>` jest kebab-case i to **ona** nazywa komendę u klientów bez natywnych
+skilli — nie pole `name:` z frontmatter. Trzymaj oba zgodne, żeby skill nazywał
+się tak samo wszędzie.
+
+Nazwa nie może kolidować z agentem z `templates/shared/agents/` — u pięciu klientów
+obie rzeczy lądują w tym samym katalogu komend i druga nadpisze pierwszą.
+
+## Frontmatter
+
+```yaml
+---
+name: <kebab-case, ten sam co katalog>
+description: >-
+  <co robi> + <kiedy to odpalić>
+disable-model-invocation: true   # opcjonalnie
+---
+```
+
+`description` to **jedyny** mechanizm odpalania. Model widzi zawsze tylko `name`
+i `description`; treść czyta dopiero, gdy zdecyduje, że skill pasuje. Cała
+informacja „kiedy tego użyć" musi więc być tutaj, nie w treści.
+
+Modele mają skłonność do **niedoodpalania** skilli — pomijają je w sytuacjach,
+w których byłyby przydatne. Dlatego opis pisz napastliwie: wymień konkretne
+zdania i konteksty, nie tylko temat. Zamiast „Konwencje migracji bazy" napisz
+„Konwencje migracji bazy. Użyj zawsze, gdy pojawia się migracja, zmiana schematu,
+`alembic`, `makemigrations` albo pytanie o kolejność wdrożenia — także wtedy, gdy
+użytkownik nie użyje słowa »migracja«."
+
+`disable-model-invocation: true` wyłącza automatyczne odpalanie i zostawia tylko
+wywołanie ręczne. Ustaw to wyłącznie wtedy, gdy skill jest związany z jednym
+klientem albo jego przypadkowe odpalenie byłoby szkodliwe — jak
+`templates/cursor/skills/compact/`, który dotyczy tylko Cursora.
+
+## Trzy poziomy ładowania
+
+| Poziom | Co | Kiedy w kontekście |
+| --- | --- | --- |
+| Metadane | `name` + `description` | zawsze |
+| Treść `SKILL.md` | całe ciało pliku | gdy skill odpali |
+| Zasoby | `references/`, `scripts/`, `assets/` | gdy treść po nie odeśle |
+
+Z tego wynika cała ekonomia pisania: metadane płacisz zawsze, więc mają być krótkie
+i celne; treść płacisz przy każdym odpaleniu, więc trzymaj ją poniżej ~500 linii;
+zasoby nie kosztują nic, dopóki nikt po nie nie sięgnie.
+
+Gdy `SKILL.md` puchnie ponad ten sufit, nie tnij treści — przenieś ją do
+`references/` i zostaw w `SKILL.md` jedno zdanie o tym, **kiedy** tam zajrzeć.
+Plik referencyjny powyżej 300 linii zaczynaj spisem treści, inaczej model wczyta
+całość, żeby znaleźć jeden akapit.
+
+Przy wielu wariantach jednej rzeczy organizuj przez katalog, nie przez rozrost
+treści:
+
+```text
+cloud-deploy/
+├── SKILL.md          wybór wariantu + wspólny przebieg
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+## Jak pisać treść
+
+Tryb rozkazujący, adresowany do modelu, który już zdecydował, że skill pasuje.
+Nie powtarzaj w treści warunków odpalenia — to robota `description`.
+
+Wyjaśniaj **dlaczego**, nie tylko **co**. Reguła z uzasadnieniem przeżywa kontakt
+z sytuacją, której nie przewidziałeś; sama komenda nie. Stosy wielkich liter
+i „MUSISZ" nie zastępują powodu.
+
+Gdy skill ma produkować konkretny kształt wyniku, pokaż go dosłownie:
+
+```markdown
+## Struktura raportu
+Zawsze dokładnie ten szablon:
+# [Tytuł]
+## Podsumowanie
+## Ustalenia
+## Rekomendacje
+```
+
+Przykłady wpisuj jako pary wejście/wyjście — jedna para konkretna warta jest
+trzech akapitów opisu.
+
+Pisz ogólnie na tyle, żeby skill przeżył zmianę przykładu. Skill zbudowany wokół
+jednego pliku z repo umiera przy pierwszym refaktorze.
+
+## Zasada braku zaskoczenia
+
+Skill nie może robić niczego, czego nie zapowiada jego opis. Żadnego kodu, który
+sięga poza zadeklarowany zakres, wysyła dane na zewnątrz albo obchodzi bramki
+projektu. Skill opisany zdaniem musi dać się z tego zdania w całości przewidzieć.
+
+## Co się stanie z twoim skillem u innych klientów
+
+`scripts/install_shared_skills.py` rozkłada `templates/shared/skills/` na osiem
+klientów. Trzy czytają skille natywnie, pięć nie ma takiego formatu:
+
+| Klient | Gdzie ląduje | Jak działa |
+| --- | --- | --- |
+| claude | `.claude/skills/` | natywnie, z zasobami |
+| cursor | `.cursor/skills/` | natywnie, z zasobami |
+| antigravity | `.agents/skills/` | natywnie, z zasobami |
+| codex | `.codex/agents/` | degradacja: komenda `/nazwa` |
+| vscode | `.github/prompts/` | degradacja: komenda `/nazwa` |
+| kiro | `.kiro/agents/` | degradacja: komenda `/nazwa` |
+| kilo | `.kilocode/workflows/` | degradacja: komenda `/nazwa` |
+| opencode | `.opencode/command/` | degradacja: komenda `/nazwa` |
+
+Degradacja ma dwa skutki, z którymi trzeba pisać: skill przestaje odpalać się sam
+(ktoś musi wpisać `/nazwa`) i **gubi wszystko poza `SKILL.md`** — komenda to jeden
+plik. Skill, którego sens leży w `scripts/`, będzie w pięciu na osiem klientów
+wydmuszką. Jeśli tak wychodzi, przemyśl, czy to nie powinien być agent.
+
+Instalator ostrzega o gubionych katalogach na stderr. Traktuj to ostrzeżenie jako
+sygnał projektowy, nie szum.
+
+## Zanim uznasz skill za skończony
+
+- `description` mówi **kiedy** odpalić, konkretnymi zdaniami użytkownika
+- `name` == nazwa katalogu i nie koliduje z agentem
+- `SKILL.md` poniżej ~500 linii, nadmiar w `references/`
+- treść nie powtarza warunków odpalenia
+- skill przeżywa degradację do jednego pliku, albo świadomie z niej rezygnuje
+- `bootstrap-project.sh --clients all` instaluje go u wszystkich ośmiu klientów

--- a/.cursor/agents/create-skill.md
+++ b/.cursor/agents/create-skill.md
@@ -1,0 +1,258 @@
+---
+name: create-skill
+description: Pomysł na skill → rozstrzygnięcie skill czy agent → ocena na tle repo → karta → issue. Use when /create-skill, "chcę mieć skill na X", nowy SKILL.md, wiedza którą model ma ładować sam. Nie pisze skilla. Wywołuj jako /create-skill.
+---
+
+## Reguły wspólne
+
+Przestrzegaj `.cursor/rules/git-branch-pr.mdc` i `AGENTS.md`. Nie zakładasz brancha,
+nie piszesz skilla, nie commitujesz. Wyjściem jest **issue albo jego brak**.
+
+# /create-skill — od pomysłu na skill do zaakceptowanego issue
+
+Robisz trzy rzeczy, których `gh issue create` nie robi: **rozstrzygasz, czy to w ogóle
+skill** (bardzo często okazuje się agentem), **oceniasz pomysł na tle prawdziwego repo**
+i **nic nie tworzysz bez pętli akceptacji**. Wymagane: `gh` (zalogowany), `git`. Język
+prozy z MCP `get_language` (domyślnie PL). **Tytuł issue zawsze po angielsku**; body
+w języku ustawienia.
+
+**W fazach 0–3 wyłącznie odczyty.** Cokolwiek zmienia stan GitHuba, czeka na FAZĘ 4.
+
+Rzemiosło pisania skilla — frontmatter, sufity długości, zasoby, degradacja — trzyma
+skill `skill-authoring`. Nie powtarzaj go tutaj; odsyłaj do niego w issue.
+
+## `--help` / `help` / `-h`
+
+Gdy user poda `--help`, `help` lub `-h` — **nie oceniaj i nie twórz**, wypisz pomoc i zakończ.
+
+```markdown
+# /create-skill — pomoc
+
+## Co robi
+Rozstrzyga czy pomysl to skill czy agent, ocenia go na tle repo, dopytuje
+o braki, sklada karte (nazwa, description, zasoby, klienci, kryterium)
+i tworzy issue dopiero po Twojej akceptacji. Nie pisze SKILL.md.
+
+## Wywolanie
+/create-skill                      Pyta o pomysl od zera
+/create-skill "konwencje migracji" Zaczyna od tego zdania
+/create-skill --dry-run            Konczy na karcie, nie tworzy niczego
+/create-skill --no-assign          Nie przypisuje @me (backlog)
+/create-skill --parent #88         Tworzy jako sub-issue pod #88
+/create-skill --quick              Pomija FAZE 1, zaklada ze to skill i ma sens
+
+## Wyjscie
+Numer issue + link. Przy --dry-run lub anulowaniu: sama karta.
+Potem: /git-start <N>
+```
+
+**Flag `--label`, `--title`, `--body` nie ma i nie dodawaj** — etykietę i tytuł
+weryfikujesz w FAZIE 4, podanie ich z góry omijałoby tę weryfikację. Flagi spoza
+listy z pomocy nie obsługujesz: nazwij nieznaną i zapytaj, zamiast zgadywać.
+
+## FAZA 0 — rozpoznanie repo
+
+Zanim cokolwiek powiesz, czytaj. Nie pytaj o nic, czego możesz dowiedzieć się sam.
+
+| Co | Po co | Komenda |
+| --- | --- | --- |
+| Istniejące skille | Czy to już jest; jak wyglądają sąsiedzi | `ls templates/shared/skills/ templates/cursor/skills/` |
+| Agenci | Kolizja nazw — u pięciu klientów lądują w tym samym katalogu | `ls templates/shared/agents/` |
+| Konwencje repo | Czy pomysł nie łamie ustalonych zasad | `cat AGENTS.md` |
+| Istniejące issue | Czy to już zgłoszone | `gh issue list --state all --search "<słowa>" --limit 20` |
+| Etykiety | Żeby nie wymyślać nieistniejących | `gh label list --limit 50` |
+
+**Limit: pięć odczytów; żadnego czytania plików w całości poza `AGENTS.md`.** Bez limitu
+ta faza zjada kontekst i nie zostaje miejsce na rozmowę. Streść odczyty jednym zdaniem,
+nie relacjonuj linijka po linijce.
+
+## FAZA 1 — skill czy agent, i czy w ogóle
+
+Wydaj **jeden z sześciu werdyktów**. Zawsze wprost, zawsze w pierwszym zdaniu.
+
+| Werdykt | Co znaczy | Co dalej |
+| --- | --- | --- |
+| **Ma sens** | To skill, nie ma go, da się wpiąć | FAZA 2 |
+| **Ma sens, ale** | To skill, ale coś trzeba przestawić | FAZA 2, uwagi w karcie |
+| **To nie skill, to agent** | Wiedza ma sens tylko wywołana ręcznie | Odeślij do `/create-task`, koniec |
+| **Już istnieje** | Zrobione albo zgłoszone | Link, pytanie czy mimo to |
+| **Nie w tej formie** | Cel dobry, ujęcie złe | Propozycja innego ujęcia |
+| **Nie w tym projekcie** | To nie należy do kita | Uzasadnienie, koniec |
+
+Werdykt „nie" i werdykt „to agent" muszą być **realnymi możliwościami**. Jeśli zawsze
+mówisz „świetny skill", nie ma po co czytać repo.
+
+### Rozstrzygnięcie skill vs agent
+
+To najważniejsza rzecz, którą tu robisz, bo użytkownik mówi „skill" na jedno i drugie.
+
+| | Skill | Agent |
+| --- | --- | --- |
+| Kto odpala | model sam, po `description` | człowiek, przez `/nazwa` |
+| Kiedy | gdy rozpozna pasujący kontekst | gdy ktoś zdecyduje |
+| Wynik | zmienia sposób pracy nad czymś innym | konkretny artefakt tu i teraz |
+| Kształt | wiedza, konwencje, kryteria | przebieg, fazy, kroki |
+| Zasoby | `references/`, `scripts/`, `assets/` | jeden plik |
+
+Test rozstrzygający: **czy ta treść ma sens, gdy nikt jej nie wywoła?** Konwencje migracji
+przydają się w chwili, gdy ktoś pisze migrację, choćby nie wiedział, że skill istnieje —
+skill. „Zbierz diff, oceń, zrób PR" nie zadzieje się bez decyzji — agent.
+
+Drugi sygnał: jeśli pomysł da się zapisać jako **fazy i kroki z pętlą akceptacji**, to
+agent. Skill nie ma faz, bo nie wie, w którym momencie pracy go wczytano.
+
+Uwagi jako lista, każda w jednej linii, każda z konsekwencją, bez zmiękczania. Na końcu
+**obowiązkowo** „Idziemy dalej czy odpuszczamy?" — temat ma móc upaść tutaj.
+
+`--quick` pomija tę fazę w całości.
+
+## FAZA 2 — dopytywanie
+
+Pytaj **tylko o to, czego nie wyczytałeś z repo**. Dla skilla zostają w praktyce cztery
+niewiadome, a `description` bez pierwszej z nich jest bezużyteczne:
+
+1. **Jakie zdania użytkownika mają go odpalić?** Konkretne sformułowania, nie temat.
+   To wprost materiał na `description`, a modele niedoodpalają skille — bez tego skill
+   będzie leżał nietknięty.
+2. **Co jest wynikiem?** Zmieniony sposób pracy, format wyjścia, kryteria oceny.
+3. **Czy potrzebuje czegoś obok `SKILL.md`?** `references/`, `scripts/`, `assets/`.
+4. **Czy ma się odpalać sam?** `disable-model-invocation: true` tylko wtedy, gdy skill
+   jest związany z jednym klientem albo przypadkowe odpalenie byłoby szkodliwe.
+
+**Limit: cztery pytania.** Piąte znaczy, że pomysł nie jest gotowy na issue — powiedz to
+wprost i odeślij do `/grill-me`.
+
+Nazwę, klientów i etykietę **proponujesz sam** i pokazujesz w karcie.
+
+## FAZA 3 — karta issue
+
+Karta jest **pełnym podglądem tego, co się wydarzy**: treść i każde pole, które ustawisz
+w GitHubie. Zasada: **nic, czego nie ma na karcie, nie zostanie ustawione.**
+
+```text
+╭─ KARTA ISSUE (skill) ─────────────────────────────────────────╮
+Tytul      Add <name> skill for <co>
+Etykieta   type: feature                  [istnieje w repo]
+Assignee   @me                            [brak przy --no-assign]
+Rodzic     brak                           [#88 przy --parent]
+Katalog    templates/shared/skills/<name>/
+Zasoby     brak | references/ scripts/ assets/
+Klienci    wszyscy (3 natywnie, 5 przez degradacje do komendy)
+──────────────────────── TRESC ─────────────────────────────────
+
+## Co ma dzialac
+Jedno zdanie stanu: co model ma umiec, gdy skill istnieje.
+
+## Frontmatter
+name: <kebab-case>
+description: <co robi + kiedy odpalic, konkretnymi zdaniami>
+<disable-model-invocation: true — tylko jesli uzasadnione>
+
+## Zakres
+- templates/shared/skills/<name>/SKILL.md — <sekcje>
+- <zasoby, jesli sa>
+Poza zakresem: <co swiadomie odpada>
+
+## Kryterium ukonczenia
+Odpala sie: <zdanie uzytkownika, po ktorym skill ma wejsc>
+Nie odpala sie: <sytuacja, w ktorej ma zostac w spokoju>
+Instalacja: bootstrap --clients all instaluje go u wszystkich klientow
+
+## Plan skrocony
+1. … (3–5 punktow)
+
+## Otwarte pytanie
+<niewiadoma + zalozenie domyslne>
+
+## Kontekst
+<skad sie wzielo> + <konkret z repo: sciezka, numer issue>
+Rzemioslo: skill `skill-authoring`.
+╰───────────────────────────────────────────────────────────────╯
+
+[t] tworze   [a] anuluj   albo napisz, co zmienic
+```
+
+**Kryterium odpalenia i nieodpalenia** to jedyny sposób sprawdzić `description` bez
+zgadywania — skill, który wchodzi wszędzie, jest tak samo zepsuty jak ten, który nie
+wchodzi nigdzie. `Kontekst` z ogólnikiem („pasuje do kita") = sygnał, że FAZA 0 nie zadziałała.
+
+## FAZA 4 — pętla akceptacji
+
+Trzy wyjścia; tylko jedno kończy się utworzeniem issue.
+
+**Przy `--dry-run` wyjścia `t` nie ma.** Zmiany przyjmujesz dalej, na `t` odmawiasz
+i przypominasz, żeby powtórzyć bez flagi. Zero komend `gh`, które cokolwiek zmieniają.
+
+### `t` — tworzę
+
+Dopiero tutaj lecą komendy zapisujące i raportujesz każdą. Repo `gh` bierze z klona;
+`<owner>/<repo>` z `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+```bash
+gh issue create \
+  --title "<title EN>" \
+  --label "<etykieta z karty>" \
+  --assignee @me \
+  --body-file - <<'BODY'
+…tresc z karty…
+BODY
+
+# tylko przy --parent; w sciezce numer issue, w sub_issue_id numeryczne db id
+gh api --method POST repos/<owner>/<repo>/issues/<parent>/sub_issues \
+  -F sub_issue_id=$(gh api repos/<owner>/<repo>/issues/<N> --jq .id)
+```
+
+Przy `--no-assign` opuszczasz `--assignee @me`; karta ma wtedy `Assignee brak`.
+
+Numer bierz **tylko z outputu `create`** — nigdy `gh issue list --limit 1`. Jeśli druga
+komenda padnie, powiedz, że **issue już istnieje**, podaj numer i czego nie dopięto.
+Kończ raportem: numer, link, `/git-start <N>`.
+
+### `a` — anuluj
+
+Temat upada, nic nie powstaje. **Nie** ratuj pomysłu i nie pytaj „na pewno?".
+Jedyne, co proponujesz: zapis karty do `.scratch/` — też tylko za zgodą.
+
+### Cokolwiek innego — zmiana
+
+**Weryfikuj zmianę, zanim ją przyjmiesz**, potem wróć do FAZY 3 z nową kartą i jedną
+linijką o tym, co się zmieniło.
+
+| Zmieniasz | Co sprawdzasz |
+| --- | --- |
+| Nazwę | kebab-case; brak kolizji w `shared/skills` **i** `shared/agents` |
+| `description` | Czy mówi kiedy odpalić, czy tylko o czym jest |
+| Zasoby | Czy skill przeżyje degradację do jednego pliku bez nich |
+| Etykietę | Czy istnieje (`gh label list`); czy pasuje do treści |
+| Tytuł | Czy po angielsku; czy opisuje stan, nie czynność |
+| Kryterium | Czy da się je sprawdzić bez pytania użytkownika |
+| Rodzica | Czy issue istnieje i jest otwarte |
+
+**Etykieta — trzy przypadki:** istnieje i pasuje → podmień; istnieje, ale nie pasuje →
+podmień i powiedz, dlaczego to podejrzane, nie blokuj; nie istnieje → nie twórz po cichu,
+zaproponuj `gh label create` i **zapytaj osobno**. To **jedyny** zapis dozwolony przed `t`,
+i nie przy `--dry-run`.
+
+**Zmiana, która wywraca werdykt:** jeśli po zmianie pomysł jest już agentem, a nie skillem
+— powiedz to **zanim** pokażesz kartę i odeślij do `/create-task`. Bez tego pętla
+akceptacji staje się drogą do przemycenia agenta w przebraniu skilla.
+
+**Czwarty obrót pętli:** zauważ to. „Zwykle znaczy to, że nie zgadzamy się co do samego
+pomysłu, a nie co do jego zapisu. Wracamy do FAZY 1?"
+
+## Etykiety
+
+Wybierasz **jedną** etykietę z istniejących (`gh label list`) — tę, która odpowiada typowi
+Conventional z `.cursor/rules/git-branch-pr.mdc`, żeby `/git-start` → `/git-commit` →
+`/git-end` się nie rozjechało. Nowy skill to zwykle `type: feature`, poprawka istniejącego
+`type: fix` lub `type: docs`.
+
+## Zakazy
+
+- Nie twórz issue ani niczego w GitHubie przed `t` w FAZIE 4. Jedyny wyjątek:
+  `gh label create` po osobnej zgodzie, i nie przy `--dry-run`.
+- Nie pisz `SKILL.md` i nie zakładaj katalogu skilla — od tego jest `/git-start`.
+- Nie powtarzaj w issue treści skilla `skill-authoring` — odeślij do niego.
+- Nie przyjmuj zmiany z FAZY 4 na słowo, bez weryfikacji.
+- Nie zakładaj skilla o nazwie kolidującej z agentem.
+- Nie rozpisuj specyfikacji — plan to sufit pięciu punktów.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,12 @@ Konflikt TDD: Matt `/tdd` *albo* Superpowers TDD — nie oba. Domyślnie Matt na
 Pełna reguła: `.cursor/rules/git-branch-pr.mdc`.
 
 ```text
-[/create-task gdy nie ma issue] → [/grill-me gdy scope niejasny] → /git-start → [worktree?] → kod [+/tdd]
+[/create-task | /create-skill gdy nie ma issue] → [/grill-me gdy scope niejasny] → /git-start → [worktree?] → kod [+/tdd]
   → [/git-check] → /git-commit → /review-bugbot (+ min. stack) → /git-end | finishing→PR → Autopilot → merge
 ```
 
 - **`/create-task`** — pomysł → ocena na tle repo → karta issue → issue po akceptacji. Przed `/git-start`; nie zakłada brancha.  
+- **`/create-skill`** — to samo dla skilli: najpierw rozstrzyga, czy pomysł to skill czy agent (wtedy odsyła do `/create-task`), potem karta i issue. Nie pisze `SKILL.md`.  
 - **`/git-start` / `/git-check` / `/git-commit` / `/git-end`** — issue, sync, Conventional commit(s), push+PR.  
 - **`/grill-me`** — tylko przy niejasnym scope / trade-offach (nie przy oczywistym fixie).  
 - **`/teacher-backend` / `/teacher-frontend` / `/teacher-architecture`** — nauka **przed** kodem: koncepcja, „dlaczego tak”, opcje i koszty. Nie edytują plików; nie mylić z `/review-*` (te działają na gotowym diffie).  
@@ -91,6 +92,7 @@ Docelowo też flaga MCP `--codegen` (design — jeszcze nie w CLI). Review FE/BE
 |---------|-----------|--------|
 | `/compact` | **Cursor only** — alias Summarize; nie Claude/Codex | kit → `.cursor/skills/compact/` |
 | `/create-task` | `/create-task "…"`; flagi: `/create-task --help` | kit |
+| `/create-skill` | `/create-skill "…"`; flagi: `/create-skill --help` | kit |
 | `/git-*` | `/git-start`, `/git-check`, `/git-commit`, `/git-end` | kit |
 | `/review-*` | `/review-backend`, `/review-bugbot` | kit + Cursor |
 | `/subagent-*` | `/subagent-backend` | kit |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Centralne repo MD + serwer MCP. Projekty wybierają **kategorię** (`--preset`) 
 | Zmiana zestawu modułów vs kategoria          | `.ai/project.profile.yaml` + `--profile` (fork)         |
 | Docelowy kontrakt `--profile` / stack / `--overlays` / `--codegen` | [design overlays](docs/specs/2026-08-05-mcp-profile-architecture-overlays-design.md) (**CLI stack jeszcze nie**) |
 | Cursor `/compact` (alias Summarize)          | `templates/cursor/skills/compact/` → `.cursor/skills/` (nie Claude/Codex) |
+| Skille kita (wszyscy klienci)                | `templates/shared/skills/` → sekcja „Skille kita” niżej |
 
 
 ## Struktura `docs/`
@@ -400,6 +401,7 @@ Gdy pokaże zmiany: `bootstrap-project.sh` ponownie z tymi samymi flagami co pop
 | `/compact`    | **Cursor only** — alias UI Summarize w tym projekcie | `/compact`                                                                                                                                         |
 | `/git-*`      | Start / sync issue / commit / PR                   | `/git-start`, `/git-check`, `/git-commit`, `/git-end`                                                                                               |
 | `/create-task` | Pomysł → ocena na tle repo → issue (bez brancha)   | `/create-task`, `/create-task "eksport CSV"`; flagi: `/create-task --help`                                                                          |
+| `/create-skill` | Pomysł na skill → skill czy agent → issue (bez brancha) | `/create-skill`, `/create-skill "konwencje migracji"`; flagi: `/create-skill --help`                                                            |
 | `/review-*`   | Review tylko do odczytu, raport                      | `/review-backend`, `/review-frontend`, `/review-architecture`, `/review-ui`, `/review-edge`, `/review-tests`, `/review-bugbot`, `/review-security` |
 | `/subagent-*` | Praca w dwóch oknach (wymiana raportów)              | `/subagent-backend`, `/subagent-frontend`                                                                                                          |
 
@@ -451,6 +453,7 @@ Długo:    [/grill-me] → /git-start → worktree → kod → [/git-check] → 
 | Komenda kit  | Co robi                                                                                 |
 | ------------ | --------------------------------------------------------------------------------------- |
 | `/create-task` | Ocena pomysłu na tle repo → karta issue → utworzenie po akceptacji; `--dry-run` / `--quick` / `--split` / `--no-assign` / `--parent #N`. **Nie** zakłada brancha |
+| `/create-skill` | Rozstrzyga skill vs agent, potem karta issue z nazwą, `description` i kryterium odpalenia; `--dry-run` / `--quick` / `--no-assign` / `--parent #N`. **Nie** pisze `SKILL.md` |
 | `/git-start` | `#N` / opis / **puste = auto-diff** / `--help` (ręcznie: `gh issue create` / `develop`) |
 | `/git-check` | Dopasuj tytuł (EN) i body (język MCP) issue do realnego diffa; `--dry-run`              |
 | `/git-commit` | Conventional Commit(s) z diffa; `--one` (jeden) / `--split` / `--dry-run`; odpala pre-commit |
@@ -487,6 +490,7 @@ UI: GitHub Issue → Development → **Create a branch** (potem nazwij spójnie 
 | Slash                                | Plik szablonu                                    |
 | ------------------------------------ | ------------------------------------------------ |
 | `/create-task`                       | `templates/shared/agents/create-task.md`         |
+| `/create-skill`                      | `templates/shared/agents/create-skill.md`        |
 | `/git-start`                         | `templates/shared/agents/git-start.md`           |
 | `/git-check`                         | `templates/shared/agents/git-check.md`           |
 | `/git-commit`                        | `templates/shared/agents/git-commit.md`          |
@@ -558,6 +562,36 @@ Po skopiowaniu/wyrenderowaniu **zrestartuj** okno IDE — agenty/komendy ładuj�
 ```
 
 
+
+## Skille kita — wspólne źródło
+
+Skill to wiedza, którą model ładuje **sam**, gdy `description` pasuje do sytuacji —
+w odróżnieniu od agenta (`/nazwa`), którego ktoś musi wywołać. Jedno źródło:
+**`templates/shared/skills/<nazwa>/SKILL.md`** (+ opcjonalne `references/`, `scripts/`,
+`assets/`). Rozkłada je `scripts/install_shared_skills.py`.
+
+| Klient | Gdzie ląduje | Jak działa |
+|--------|--------------|------------|
+| claude | `.claude/skills/` | natywnie, z zasobami |
+| cursor | `.cursor/skills/` | natywnie, z zasobami (obok Cursor-only `/compact`) |
+| antigravity | `.agents/skills/` | natywnie, z zasobami |
+| codex | `.codex/agents/` | degradacja: komenda `/nazwa` |
+| vscode | `.github/prompts/` | degradacja: komenda `/nazwa` |
+| kiro | `.kiro/agents/` | degradacja: komenda `/nazwa` |
+| kilo | `.kilocode/workflows/` | degradacja: komenda `/nazwa` |
+| opencode | `.opencode/command/` | degradacja: komenda `/nazwa` |
+
+**Degradacja kosztuje dwie rzeczy:** skill przestaje odpalać się sam (trzeba wpisać
+`/nazwa`) i gubi wszystko poza `SKILL.md`, bo komenda to jeden plik. Instalator mówi
+o gubionych katalogach na stderr. Skill, którego sens leży w `scripts/`, będzie
+w pięciu na osiem klientów wydmuszką — wtedy to prawdopodobnie powinien być agent.
+
+`.claude/skills/` i `.agents/skills/` dzielisz ze skillami spoza kita (`npx skills add`),
+więc odznaczenie klienta kasuje tam **tylko** katalogi o nazwach ze wspólnego źródła,
+nigdy całego katalogu skilli.
+
+Nowy skill zakładasz przez **`/create-skill`** (issue), a piszesz według skilla
+`skill-authoring` — to on trzyma zasady frontmatter, sufity długości i kryteria odpalania.
 
 ## Guardrails — bezpieczeństwo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,11 @@ build-backend = "hatchling.build"
 
 # `unittest discover -s tests` i pytest wkładają `tests/` na sys.path, więc suity
 # mogą się nawzajem importować (test_shell_suites → test_bash_hook_launcher).
-# Type checker musi widzieć ten sam import root.
+# Python robi to samo dla katalogu uruchamianego skryptu, stąd `scripts/`
+# (install_shared_skills → render_agent_commands). Type checker musi widzieć te
+# same import rooty co runtime.
 [tool.ty.environment]
-extra-paths = ["tests"]
+extra-paths = ["tests", "scripts"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/guides"]

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -9,6 +9,8 @@
 # Domyślny preset: _base. Domyślni klienci: all.
 # Kategoria e-commerce: --preset shop
 # Agenci: templates/shared/agents → natywne ścieżki klienta.
+# Skille: templates/shared/skills → katalog skilli klienta (claude/cursor/antigravity)
+#         albo komenda /nazwa u pozostałych (patrz scripts/install_shared_skills.py).
 
 set -euo pipefail
 
@@ -27,7 +29,8 @@ Opcje:
   --from SOURCE       Źródło uvx: ścieżka lokalna lub git+https://… (domyślnie: placeholder GitHub)
   --with-profile      Skopiuj templates/project.profile.yaml → .ai/project.profile.yaml (tylko fork)
   --with-overlay      Skopiuj templates/project.md → .ai/project.md (jeśli brak)
-  --skip-agents       Nie kopiuj agentów (/git-*, /review-*, /subagent-*)
+  --skip-agents       Nie kopiuj agentów (/git-*, /review-*, /subagent-*) ani skilli
+                      z templates/shared/skills/
   --with-plugins      Best-effort doinstaluj zewnętrzne pluginy (mattpocock skills przez npx;
                       Superpowers/Autopilot tylko instrukcja — to marketplace pluginów Claude/Cursor,
                       nie da się zainstalować z skryptu). Wymaga npx w PATH (Node.js)
@@ -65,6 +68,7 @@ PRUNE_CLIENTS=1
 KIT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SHARED_AGENTS="$KIT_ROOT/templates/shared/agents"
 SHARED_GUARDS="$KIT_ROOT/templates/shared/guards"
+SHARED_SKILLS="$KIT_ROOT/templates/shared/skills"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -192,6 +196,7 @@ prune_client() {
     claude)
       rm -f "$TARGET/.mcp.json"
       rm -rf "$TARGET/.claude/agents" "$TARGET/.claude/commands" "$TARGET/.claude/hooks"
+      prune_shared_skills "$TARGET/.claude/skills"
       if [[ -f "$TARGET/.claude/settings.json" ]]; then
         "$PYTHON_BIN" "$KIT_ROOT/scripts/claude_settings.py" prune "$TARGET/.claude/settings.json"
       fi
@@ -223,6 +228,7 @@ prune_client() {
     antigravity)
       rm -f "$TARGET/.agents/mcp_config.json"
       rm -rf "$TARGET/.agents/workflows"
+      prune_shared_skills "$TARGET/.agents/skills"
       rmdir "$TARGET/.agents" 2>/dev/null || true
       ;;
     opencode)
@@ -308,6 +314,37 @@ copy_shared_agents() {
   echo "  + $dest_dir (shared agents)"
 }
 
+# Skille ze wspólnego źródła. Trzy klienty mają natywny katalog skilli, pozostałe
+# dostają je jako komendę `/nazwa` — mapę i degradację trzyma install_shared_skills.py,
+# tutaj zostaje tylko decyzja "czy w ogóle" i dokąd.
+copy_shared_skills() {
+  local client="$1" dest_dir="$2"
+  if [[ "$SKIP_AGENTS" -ne 0 ]]; then
+    return 0
+  fi
+  # Puste źródło to poprawny stan (kit bez skilli) — inaczej niż przy agentach,
+  # gdzie brak katalogu znaczy uszkodzony kit.
+  if ! compgen -G "$SHARED_SKILLS/*/SKILL.md" >/dev/null; then
+    return 0
+  fi
+  "$PYTHON_BIN" "$KIT_ROOT/scripts/install_shared_skills.py" \
+    "$client" "$SHARED_SKILLS" "$dest_dir"
+  echo "  + $dest_dir (shared skills, $client)"
+}
+
+# Kitowe skille w katalogu, który dzielimy z użytkownikiem (.claude/skills,
+# .agents/skills — tam lądują też skille instalowane spoza kita). Kasujemy więc
+# po nazwach ze źródła, nigdy całego katalogu.
+prune_shared_skills() {
+  local dest_dir="$1" skill
+  [[ -d "$dest_dir" ]] || return 0
+  for skill in "$SHARED_SKILLS"/*/; do
+    [[ -d "$skill" ]] || continue
+    rm -rf "$dest_dir/$(basename "$skill")"
+  done
+  rmdir "$dest_dir" 2>/dev/null || true
+}
+
 install_agenty_md_once() {
   if [[ ! -f "$TARGET/AGENTS.md" ]]; then
     cp "$KIT_ROOT/templates/AGENTS.md" "$TARGET/AGENTS.md"
@@ -360,6 +397,8 @@ install_cursor() {
     cp -R "$KIT_ROOT/templates/cursor/skills/." "$TARGET/.cursor/skills/"
     echo "  + .cursor/skills/ (Cursor-only, np. /compact)"
   fi
+
+  copy_shared_skills cursor "$TARGET/.cursor/skills"
 }
 
 copy_claude_commands() {
@@ -415,6 +454,7 @@ install_claude() {
 
   copy_shared_agents "$TARGET/.claude/agents"
   copy_claude_commands "$TARGET/.claude/commands"
+  copy_shared_skills claude "$TARGET/.claude/skills"
 }
 
 install_codex() {
@@ -430,6 +470,7 @@ install_codex() {
       "$TARGET/.codex/agents" "$KIT_ROOT/templates/codex/agents"
     echo "  + .codex/agents/ (curated + auto-rendered)"
   fi
+  copy_shared_skills codex "$TARGET/.codex/agents"
 }
 
 render_agent_commands() {
@@ -455,6 +496,7 @@ install_vscode() {
     echo "  + .github/copilot-instructions.md"
   fi
   render_agent_commands vscode "$TARGET/.github/prompts"
+  copy_shared_skills vscode "$TARGET/.github/prompts"
 }
 
 install_kiro() {
@@ -466,6 +508,7 @@ install_kiro() {
       "$TARGET/.kiro/steering/instruction-kit.md"
   fi
   copy_shared_agents "$TARGET/.kiro/agents"
+  copy_shared_skills kiro "$TARGET/.kiro/agents"
 }
 
 install_kilo() {
@@ -473,6 +516,7 @@ install_kilo() {
   fill_mcp "$KIT_ROOT/templates/kilo/mcp.json" "$TARGET/.kilocode/mcp.json"
   echo "  + .kilocode/mcp.json"
   render_agent_commands kilo "$TARGET/.kilocode/workflows"
+  copy_shared_skills kilo "$TARGET/.kilocode/workflows"
 }
 
 install_antigravity() {
@@ -480,6 +524,7 @@ install_antigravity() {
   fill_mcp "$KIT_ROOT/templates/antigravity/mcp_config.json" "$TARGET/.agents/mcp_config.json"
   echo "  + .agents/mcp_config.json"
   render_agent_commands antigravity "$TARGET/.agents/workflows"
+  copy_shared_skills antigravity "$TARGET/.agents/skills"
 }
 
 install_opencode() {
@@ -487,6 +532,7 @@ install_opencode() {
   fill_mcp "$KIT_ROOT/templates/opencode/opencode.json" "$TARGET/opencode.json" "$TARGET"
   echo "  + opencode.json"
   render_agent_commands opencode "$TARGET/.opencode/command"
+  copy_shared_skills opencode "$TARGET/.opencode/command"
 }
 
 install_plugins() {

--- a/scripts/install_shared_skills.py
+++ b/scripts/install_shared_skills.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Zainstaluj templates/shared/skills/*/SKILL.md do katalogu klienta.
+
+Użycie:
+    install_shared_skills.py CLIENT SRC_DIR DEST_DIR
+
+Trzy klienty czytają skille natywnie (`<nazwa>/SKILL.md` w katalogu skilli) —
+dla nich instalacja to kopia całego katalogu razem z `scripts/`, `references/`
+i `assets/`. Reszta nie ma formatu skilla, więc skill degraduje się do komendy
+`/nazwa` w formacie danego klienta: nadal jest dostępny, ale trzeba go wywołać
+ręcznie zamiast liczyć na to, że model sam go załaduje z `description`.
+
+Zasoby obok SKILL.md przy degradacji przepadają — komenda to jeden plik. Skrypt
+mówi o tym głośno, bo skill, który w połowie klientów gubi swoje `scripts/`,
+jest gorszy niż skill, którego tam po prostu nie ma.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from render_agent_commands import DEST_SUFFIX, RENDERERS
+
+# Klienci z natywnym katalogiem skilli. Dokąd dokładnie trafiają, decyduje
+# bootstrap — tutaj liczy się tylko to, że dostają katalog, a nie jeden plik.
+NATIVE_CLIENTS = {"claude", "cursor", "antigravity"}
+
+# Klient bez natywnych skilli → format renderera z render_agent_commands.
+# `kiro` czyta surowe pliki agentów, więc nie ma dla niego renderera — kopiujemy
+# SKILL.md bez zmian, tak samo jak robi to copy_shared_agents().
+DEGRADED_CLIENTS = {
+    "codex": "codex",
+    "vscode": "vscode",
+    "kilo": "kilo",
+    "opencode": "opencode",
+    "kiro": None,
+}
+
+# Katalogi, które skill może mieć obok SKILL.md (kolejność jak w dokumentacji).
+BUNDLED_DIRS = ("scripts", "references", "assets")
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Frontmatter skilla → (pola, treść).
+
+    Własny parser zamiast tego z render_agent_commands, bo skille używają
+    składanych bloków YAML (`description: >-` i wcięte linie pod spodem) —
+    parser liniowy `key: value` zwróciłby dla nich dosłowne ">-".
+    """
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise ValueError("brak frontmatter")
+    end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+    if end is None:
+        raise ValueError("niedomknięty frontmatter")
+
+    meta: dict[str, str] = {}
+    key: str | None = None
+    folded: list[str] = []
+    for line in lines[1:end]:
+        stripped = line.strip()
+        if key is not None and (line.startswith((" ", "\t")) or not stripped):
+            if stripped:
+                folded.append(stripped)
+            continue
+        if key is not None:
+            meta[key] = " ".join(folded).strip()
+            key, folded = None, []
+        if ":" not in line:
+            continue
+        name, _, val = line.partition(":")
+        name, val = name.strip(), val.strip()
+        if val in (">", ">-", "|", "|-"):
+            key, folded = name, []
+        else:
+            meta[name] = val
+    if key is not None:
+        meta[key] = " ".join(folded).strip()
+
+    body = "".join(lines[end + 1 :])
+    while body.startswith("\n"):
+        body = body[1:]
+    return meta, body
+
+
+def iter_skills(src_dir: Path) -> list[Path]:
+    """Katalogi skilli w źródle — po jednym SKILL.md, w kolejności alfabetycznej."""
+    return sorted(p.parent for p in src_dir.glob("*/SKILL.md"))
+
+
+def install_native(skill_dir: Path, dest_dir: Path) -> None:
+    dest = dest_dir / skill_dir.name
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(skill_dir, dest)
+
+
+def install_degraded(skill_dir: Path, dest_dir: Path, fmt: str | None) -> None:
+    src = skill_dir / "SKILL.md"
+    text = src.read_text(encoding="utf-8")
+    dropped = [name for name in BUNDLED_DIRS if (skill_dir / name).is_dir()]
+    if dropped:
+        print(
+            f"UWAGA: skill {skill_dir.name} traci {', '.join(dropped)} — "
+            f"{fmt or 'kiro'} instaluje skille jako komendę, czyli jeden plik",
+            file=sys.stderr,
+        )
+
+    if fmt is None:
+        # kiro: surowa kopia, nazwa pliku od skilla (SKILL.md wszędzie ta sama).
+        (dest_dir / f"{skill_dir.name}.md").write_text(text, encoding="utf-8")
+        return
+
+    meta, body = parse_frontmatter(text)
+    # `name` z frontmatter bywa inne niż katalog; komendę nazywa katalog, bo to on
+    # jest jedyną nazwą widoczną we wszystkich klientach naraz.
+    meta = {**meta, "name": skill_dir.name}
+    out = RENDERERS[fmt](meta, body)
+    suffix = DEST_SUFFIX.get(fmt, ".md")
+    (dest_dir / f"{skill_dir.name}{suffix}").write_text(out, encoding="utf-8")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 4:
+        print(__doc__, file=sys.stderr)
+        return 1
+    client, src_dir, dest_dir = argv[1], Path(argv[2]), Path(argv[3])
+
+    if client not in NATIVE_CLIENTS and client not in DEGRADED_CLIENTS:
+        print(f"Nieznany klient: {client}", file=sys.stderr)
+        return 1
+
+    skills = iter_skills(src_dir)
+    if not skills:
+        # Puste źródło to stan poprawny (kit bez skilli) — nie zakładamy katalogu
+        # w projekcie użytkownika tylko po to, żeby został pusty.
+        return 0
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for skill_dir in skills:
+        if client in NATIVE_CLIENTS:
+            install_native(skill_dir, dest_dir)
+        else:
+            install_degraded(skill_dir, dest_dir, DEGRADED_CLIENTS[client])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/templates/shared/README.md
+++ b/templates/shared/README.md
@@ -6,7 +6,13 @@ Kanon treści instrukcji (niezależny od IDE):
 |---------|------|
 | `agents/*.md` | Slash/subagenci (`/git-*`, `/review-*`, `/subagent-*`) |
 | `rules/*.md` | Reguły flow (git, review, warstwy MCP) — bez frontmatter Cursor |
+| `guards/*` | Polityka guardraili + adapter (hooki klienta) |
+| `skills/<nazwa>/SKILL.md` | Skille — wiedza, którą model ładuje sam z `description` |
 
 Adaptery (`templates/cursor`, `claude`, `codex`, `vscode`, `kiro`, `kilo`, `antigravity`) tylko formatują MCP i mapują te pliki na natywne ścieżki klienta.
+
+Skille trafiają natywnie do `claude`, `cursor` i `antigravity`; pozostali klienci dostają
+je jako komendę `/nazwa` — szczegóły degradacji w `scripts/install_shared_skills.py`
+i w skillu `skill-authoring`.
 
 Bootstrap: `scripts/bootstrap-project.sh --clients all|…`

--- a/templates/shared/agents/create-skill.md
+++ b/templates/shared/agents/create-skill.md
@@ -1,0 +1,258 @@
+---
+name: create-skill
+description: Pomysł na skill → rozstrzygnięcie skill czy agent → ocena na tle repo → karta → issue. Use when /create-skill, "chcę mieć skill na X", nowy SKILL.md, wiedza którą model ma ładować sam. Nie pisze skilla. Wywołuj jako /create-skill.
+---
+
+## Reguły wspólne
+
+Przestrzegaj `.cursor/rules/git-branch-pr.mdc` i `AGENTS.md`. Nie zakładasz brancha,
+nie piszesz skilla, nie commitujesz. Wyjściem jest **issue albo jego brak**.
+
+# /create-skill — od pomysłu na skill do zaakceptowanego issue
+
+Robisz trzy rzeczy, których `gh issue create` nie robi: **rozstrzygasz, czy to w ogóle
+skill** (bardzo często okazuje się agentem), **oceniasz pomysł na tle prawdziwego repo**
+i **nic nie tworzysz bez pętli akceptacji**. Wymagane: `gh` (zalogowany), `git`. Język
+prozy z MCP `get_language` (domyślnie PL). **Tytuł issue zawsze po angielsku**; body
+w języku ustawienia.
+
+**W fazach 0–3 wyłącznie odczyty.** Cokolwiek zmienia stan GitHuba, czeka na FAZĘ 4.
+
+Rzemiosło pisania skilla — frontmatter, sufity długości, zasoby, degradacja — trzyma
+skill `skill-authoring`. Nie powtarzaj go tutaj; odsyłaj do niego w issue.
+
+## `--help` / `help` / `-h`
+
+Gdy user poda `--help`, `help` lub `-h` — **nie oceniaj i nie twórz**, wypisz pomoc i zakończ.
+
+```markdown
+# /create-skill — pomoc
+
+## Co robi
+Rozstrzyga czy pomysl to skill czy agent, ocenia go na tle repo, dopytuje
+o braki, sklada karte (nazwa, description, zasoby, klienci, kryterium)
+i tworzy issue dopiero po Twojej akceptacji. Nie pisze SKILL.md.
+
+## Wywolanie
+/create-skill                      Pyta o pomysl od zera
+/create-skill "konwencje migracji" Zaczyna od tego zdania
+/create-skill --dry-run            Konczy na karcie, nie tworzy niczego
+/create-skill --no-assign          Nie przypisuje @me (backlog)
+/create-skill --parent #88         Tworzy jako sub-issue pod #88
+/create-skill --quick              Pomija FAZE 1, zaklada ze to skill i ma sens
+
+## Wyjscie
+Numer issue + link. Przy --dry-run lub anulowaniu: sama karta.
+Potem: /git-start <N>
+```
+
+**Flag `--label`, `--title`, `--body` nie ma i nie dodawaj** — etykietę i tytuł
+weryfikujesz w FAZIE 4, podanie ich z góry omijałoby tę weryfikację. Flagi spoza
+listy z pomocy nie obsługujesz: nazwij nieznaną i zapytaj, zamiast zgadywać.
+
+## FAZA 0 — rozpoznanie repo
+
+Zanim cokolwiek powiesz, czytaj. Nie pytaj o nic, czego możesz dowiedzieć się sam.
+
+| Co | Po co | Komenda |
+| --- | --- | --- |
+| Istniejące skille | Czy to już jest; jak wyglądają sąsiedzi | `ls templates/shared/skills/ templates/cursor/skills/` |
+| Agenci | Kolizja nazw — u pięciu klientów lądują w tym samym katalogu | `ls templates/shared/agents/` |
+| Konwencje repo | Czy pomysł nie łamie ustalonych zasad | `cat AGENTS.md` |
+| Istniejące issue | Czy to już zgłoszone | `gh issue list --state all --search "<słowa>" --limit 20` |
+| Etykiety | Żeby nie wymyślać nieistniejących | `gh label list --limit 50` |
+
+**Limit: pięć odczytów; żadnego czytania plików w całości poza `AGENTS.md`.** Bez limitu
+ta faza zjada kontekst i nie zostaje miejsce na rozmowę. Streść odczyty jednym zdaniem,
+nie relacjonuj linijka po linijce.
+
+## FAZA 1 — skill czy agent, i czy w ogóle
+
+Wydaj **jeden z sześciu werdyktów**. Zawsze wprost, zawsze w pierwszym zdaniu.
+
+| Werdykt | Co znaczy | Co dalej |
+| --- | --- | --- |
+| **Ma sens** | To skill, nie ma go, da się wpiąć | FAZA 2 |
+| **Ma sens, ale** | To skill, ale coś trzeba przestawić | FAZA 2, uwagi w karcie |
+| **To nie skill, to agent** | Wiedza ma sens tylko wywołana ręcznie | Odeślij do `/create-task`, koniec |
+| **Już istnieje** | Zrobione albo zgłoszone | Link, pytanie czy mimo to |
+| **Nie w tej formie** | Cel dobry, ujęcie złe | Propozycja innego ujęcia |
+| **Nie w tym projekcie** | To nie należy do kita | Uzasadnienie, koniec |
+
+Werdykt „nie" i werdykt „to agent" muszą być **realnymi możliwościami**. Jeśli zawsze
+mówisz „świetny skill", nie ma po co czytać repo.
+
+### Rozstrzygnięcie skill vs agent
+
+To najważniejsza rzecz, którą tu robisz, bo użytkownik mówi „skill" na jedno i drugie.
+
+| | Skill | Agent |
+| --- | --- | --- |
+| Kto odpala | model sam, po `description` | człowiek, przez `/nazwa` |
+| Kiedy | gdy rozpozna pasujący kontekst | gdy ktoś zdecyduje |
+| Wynik | zmienia sposób pracy nad czymś innym | konkretny artefakt tu i teraz |
+| Kształt | wiedza, konwencje, kryteria | przebieg, fazy, kroki |
+| Zasoby | `references/`, `scripts/`, `assets/` | jeden plik |
+
+Test rozstrzygający: **czy ta treść ma sens, gdy nikt jej nie wywoła?** Konwencje migracji
+przydają się w chwili, gdy ktoś pisze migrację, choćby nie wiedział, że skill istnieje —
+skill. „Zbierz diff, oceń, zrób PR" nie zadzieje się bez decyzji — agent.
+
+Drugi sygnał: jeśli pomysł da się zapisać jako **fazy i kroki z pętlą akceptacji**, to
+agent. Skill nie ma faz, bo nie wie, w którym momencie pracy go wczytano.
+
+Uwagi jako lista, każda w jednej linii, każda z konsekwencją, bez zmiękczania. Na końcu
+**obowiązkowo** „Idziemy dalej czy odpuszczamy?" — temat ma móc upaść tutaj.
+
+`--quick` pomija tę fazę w całości.
+
+## FAZA 2 — dopytywanie
+
+Pytaj **tylko o to, czego nie wyczytałeś z repo**. Dla skilla zostają w praktyce cztery
+niewiadome, a `description` bez pierwszej z nich jest bezużyteczne:
+
+1. **Jakie zdania użytkownika mają go odpalić?** Konkretne sformułowania, nie temat.
+   To wprost materiał na `description`, a modele niedoodpalają skille — bez tego skill
+   będzie leżał nietknięty.
+2. **Co jest wynikiem?** Zmieniony sposób pracy, format wyjścia, kryteria oceny.
+3. **Czy potrzebuje czegoś obok `SKILL.md`?** `references/`, `scripts/`, `assets/`.
+4. **Czy ma się odpalać sam?** `disable-model-invocation: true` tylko wtedy, gdy skill
+   jest związany z jednym klientem albo przypadkowe odpalenie byłoby szkodliwe.
+
+**Limit: cztery pytania.** Piąte znaczy, że pomysł nie jest gotowy na issue — powiedz to
+wprost i odeślij do `/grill-me`.
+
+Nazwę, klientów i etykietę **proponujesz sam** i pokazujesz w karcie.
+
+## FAZA 3 — karta issue
+
+Karta jest **pełnym podglądem tego, co się wydarzy**: treść i każde pole, które ustawisz
+w GitHubie. Zasada: **nic, czego nie ma na karcie, nie zostanie ustawione.**
+
+```text
+╭─ KARTA ISSUE (skill) ─────────────────────────────────────────╮
+Tytul      Add <name> skill for <co>
+Etykieta   type: feature                  [istnieje w repo]
+Assignee   @me                            [brak przy --no-assign]
+Rodzic     brak                           [#88 przy --parent]
+Katalog    templates/shared/skills/<name>/
+Zasoby     brak | references/ scripts/ assets/
+Klienci    wszyscy (3 natywnie, 5 przez degradacje do komendy)
+──────────────────────── TRESC ─────────────────────────────────
+
+## Co ma dzialac
+Jedno zdanie stanu: co model ma umiec, gdy skill istnieje.
+
+## Frontmatter
+name: <kebab-case>
+description: <co robi + kiedy odpalic, konkretnymi zdaniami>
+<disable-model-invocation: true — tylko jesli uzasadnione>
+
+## Zakres
+- templates/shared/skills/<name>/SKILL.md — <sekcje>
+- <zasoby, jesli sa>
+Poza zakresem: <co swiadomie odpada>
+
+## Kryterium ukonczenia
+Odpala sie: <zdanie uzytkownika, po ktorym skill ma wejsc>
+Nie odpala sie: <sytuacja, w ktorej ma zostac w spokoju>
+Instalacja: bootstrap --clients all instaluje go u wszystkich klientow
+
+## Plan skrocony
+1. … (3–5 punktow)
+
+## Otwarte pytanie
+<niewiadoma + zalozenie domyslne>
+
+## Kontekst
+<skad sie wzielo> + <konkret z repo: sciezka, numer issue>
+Rzemioslo: skill `skill-authoring`.
+╰───────────────────────────────────────────────────────────────╯
+
+[t] tworze   [a] anuluj   albo napisz, co zmienic
+```
+
+**Kryterium odpalenia i nieodpalenia** to jedyny sposób sprawdzić `description` bez
+zgadywania — skill, który wchodzi wszędzie, jest tak samo zepsuty jak ten, który nie
+wchodzi nigdzie. `Kontekst` z ogólnikiem („pasuje do kita") = sygnał, że FAZA 0 nie zadziałała.
+
+## FAZA 4 — pętla akceptacji
+
+Trzy wyjścia; tylko jedno kończy się utworzeniem issue.
+
+**Przy `--dry-run` wyjścia `t` nie ma.** Zmiany przyjmujesz dalej, na `t` odmawiasz
+i przypominasz, żeby powtórzyć bez flagi. Zero komend `gh`, które cokolwiek zmieniają.
+
+### `t` — tworzę
+
+Dopiero tutaj lecą komendy zapisujące i raportujesz każdą. Repo `gh` bierze z klona;
+`<owner>/<repo>` z `gh repo view --json nameWithOwner -q .nameWithOwner`.
+
+```bash
+gh issue create \
+  --title "<title EN>" \
+  --label "<etykieta z karty>" \
+  --assignee @me \
+  --body-file - <<'BODY'
+…tresc z karty…
+BODY
+
+# tylko przy --parent; w sciezce numer issue, w sub_issue_id numeryczne db id
+gh api --method POST repos/<owner>/<repo>/issues/<parent>/sub_issues \
+  -F sub_issue_id=$(gh api repos/<owner>/<repo>/issues/<N> --jq .id)
+```
+
+Przy `--no-assign` opuszczasz `--assignee @me`; karta ma wtedy `Assignee brak`.
+
+Numer bierz **tylko z outputu `create`** — nigdy `gh issue list --limit 1`. Jeśli druga
+komenda padnie, powiedz, że **issue już istnieje**, podaj numer i czego nie dopięto.
+Kończ raportem: numer, link, `/git-start <N>`.
+
+### `a` — anuluj
+
+Temat upada, nic nie powstaje. **Nie** ratuj pomysłu i nie pytaj „na pewno?".
+Jedyne, co proponujesz: zapis karty do `.scratch/` — też tylko za zgodą.
+
+### Cokolwiek innego — zmiana
+
+**Weryfikuj zmianę, zanim ją przyjmiesz**, potem wróć do FAZY 3 z nową kartą i jedną
+linijką o tym, co się zmieniło.
+
+| Zmieniasz | Co sprawdzasz |
+| --- | --- |
+| Nazwę | kebab-case; brak kolizji w `shared/skills` **i** `shared/agents` |
+| `description` | Czy mówi kiedy odpalić, czy tylko o czym jest |
+| Zasoby | Czy skill przeżyje degradację do jednego pliku bez nich |
+| Etykietę | Czy istnieje (`gh label list`); czy pasuje do treści |
+| Tytuł | Czy po angielsku; czy opisuje stan, nie czynność |
+| Kryterium | Czy da się je sprawdzić bez pytania użytkownika |
+| Rodzica | Czy issue istnieje i jest otwarte |
+
+**Etykieta — trzy przypadki:** istnieje i pasuje → podmień; istnieje, ale nie pasuje →
+podmień i powiedz, dlaczego to podejrzane, nie blokuj; nie istnieje → nie twórz po cichu,
+zaproponuj `gh label create` i **zapytaj osobno**. To **jedyny** zapis dozwolony przed `t`,
+i nie przy `--dry-run`.
+
+**Zmiana, która wywraca werdykt:** jeśli po zmianie pomysł jest już agentem, a nie skillem
+— powiedz to **zanim** pokażesz kartę i odeślij do `/create-task`. Bez tego pętla
+akceptacji staje się drogą do przemycenia agenta w przebraniu skilla.
+
+**Czwarty obrót pętli:** zauważ to. „Zwykle znaczy to, że nie zgadzamy się co do samego
+pomysłu, a nie co do jego zapisu. Wracamy do FAZY 1?"
+
+## Etykiety
+
+Wybierasz **jedną** etykietę z istniejących (`gh label list`) — tę, która odpowiada typowi
+Conventional z `.cursor/rules/git-branch-pr.mdc`, żeby `/git-start` → `/git-commit` →
+`/git-end` się nie rozjechało. Nowy skill to zwykle `type: feature`, poprawka istniejącego
+`type: fix` lub `type: docs`.
+
+## Zakazy
+
+- Nie twórz issue ani niczego w GitHubie przed `t` w FAZIE 4. Jedyny wyjątek:
+  `gh label create` po osobnej zgodzie, i nie przy `--dry-run`.
+- Nie pisz `SKILL.md` i nie zakładaj katalogu skilla — od tego jest `/git-start`.
+- Nie powtarzaj w issue treści skilla `skill-authoring` — odeślij do niego.
+- Nie przyjmuj zmiany z FAZY 4 na słowo, bez weryfikacji.
+- Nie zakładaj skilla o nazwie kolidującej z agentem.
+- Nie rozpisuj specyfikacji — plan to sufit pięciu punktów.

--- a/templates/shared/skills/skill-authoring/SKILL.md
+++ b/templates/shared/skills/skill-authoring/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skill-authoring
+description: >-
+  Jak napisać skill do instruction-kit: frontmatter, opis który faktycznie
+  odpala, sufit długości, zasoby obok SKILL.md i degradacja u klientów bez
+  natywnych skilli. Użyj tego zawsze, gdy piszesz albo poprawiasz SKILL.md,
+  realizujesz issue założone przez /create-skill, zastanawiasz się czy coś ma
+  być skillem czy agentem, albo gdy skill nie odpala się mimo że powinien.
+---
+
+# Pisanie skilla w instruction-kit
+
+Skill to wiedza, którą model **sam** ładuje, gdy rozpozna, że pasuje do sytuacji.
+Agent (`templates/shared/agents/*.md`) to przeciwieństwo: jeden przebieg, odpalany
+ręcznie przez `/nazwa`, z wynikiem tu i teraz. Jeśli twoja treść ma sens tylko wtedy,
+gdy ktoś ją wywoła — to agent, nie skill.
+
+## Gdzie to mieszka
+
+```text
+templates/shared/skills/<nazwa>/
+├── SKILL.md          wymagany
+├── references/       dokumenty czytane na żądanie
+├── scripts/          kod do odpalenia, nie do wczytania
+└── assets/           pliki lądujące w wyniku (szablony, ikony)
+```
+
+`<nazwa>` jest kebab-case i to **ona** nazywa komendę u klientów bez natywnych
+skilli — nie pole `name:` z frontmatter. Trzymaj oba zgodne, żeby skill nazywał
+się tak samo wszędzie.
+
+Nazwa nie może kolidować z agentem z `templates/shared/agents/` — u pięciu klientów
+obie rzeczy lądują w tym samym katalogu komend i druga nadpisze pierwszą.
+
+## Frontmatter
+
+```yaml
+---
+name: <kebab-case, ten sam co katalog>
+description: >-
+  <co robi> + <kiedy to odpalić>
+disable-model-invocation: true   # opcjonalnie
+---
+```
+
+`description` to **jedyny** mechanizm odpalania. Model widzi zawsze tylko `name`
+i `description`; treść czyta dopiero, gdy zdecyduje, że skill pasuje. Cała
+informacja „kiedy tego użyć" musi więc być tutaj, nie w treści.
+
+Modele mają skłonność do **niedoodpalania** skilli — pomijają je w sytuacjach,
+w których byłyby przydatne. Dlatego opis pisz napastliwie: wymień konkretne
+zdania i konteksty, nie tylko temat. Zamiast „Konwencje migracji bazy" napisz
+„Konwencje migracji bazy. Użyj zawsze, gdy pojawia się migracja, zmiana schematu,
+`alembic`, `makemigrations` albo pytanie o kolejność wdrożenia — także wtedy, gdy
+użytkownik nie użyje słowa »migracja«."
+
+`disable-model-invocation: true` wyłącza automatyczne odpalanie i zostawia tylko
+wywołanie ręczne. Ustaw to wyłącznie wtedy, gdy skill jest związany z jednym
+klientem albo jego przypadkowe odpalenie byłoby szkodliwe — jak
+`templates/cursor/skills/compact/`, który dotyczy tylko Cursora.
+
+## Trzy poziomy ładowania
+
+| Poziom | Co | Kiedy w kontekście |
+| --- | --- | --- |
+| Metadane | `name` + `description` | zawsze |
+| Treść `SKILL.md` | całe ciało pliku | gdy skill odpali |
+| Zasoby | `references/`, `scripts/`, `assets/` | gdy treść po nie odeśle |
+
+Z tego wynika cała ekonomia pisania: metadane płacisz zawsze, więc mają być krótkie
+i celne; treść płacisz przy każdym odpaleniu, więc trzymaj ją poniżej ~500 linii;
+zasoby nie kosztują nic, dopóki nikt po nie nie sięgnie.
+
+Gdy `SKILL.md` puchnie ponad ten sufit, nie tnij treści — przenieś ją do
+`references/` i zostaw w `SKILL.md` jedno zdanie o tym, **kiedy** tam zajrzeć.
+Plik referencyjny powyżej 300 linii zaczynaj spisem treści, inaczej model wczyta
+całość, żeby znaleźć jeden akapit.
+
+Przy wielu wariantach jednej rzeczy organizuj przez katalog, nie przez rozrost
+treści:
+
+```text
+cloud-deploy/
+├── SKILL.md          wybór wariantu + wspólny przebieg
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+## Jak pisać treść
+
+Tryb rozkazujący, adresowany do modelu, który już zdecydował, że skill pasuje.
+Nie powtarzaj w treści warunków odpalenia — to robota `description`.
+
+Wyjaśniaj **dlaczego**, nie tylko **co**. Reguła z uzasadnieniem przeżywa kontakt
+z sytuacją, której nie przewidziałeś; sama komenda nie. Stosy wielkich liter
+i „MUSISZ" nie zastępują powodu.
+
+Gdy skill ma produkować konkretny kształt wyniku, pokaż go dosłownie:
+
+```markdown
+## Struktura raportu
+Zawsze dokładnie ten szablon:
+# [Tytuł]
+## Podsumowanie
+## Ustalenia
+## Rekomendacje
+```
+
+Przykłady wpisuj jako pary wejście/wyjście — jedna para konkretna warta jest
+trzech akapitów opisu.
+
+Pisz ogólnie na tyle, żeby skill przeżył zmianę przykładu. Skill zbudowany wokół
+jednego pliku z repo umiera przy pierwszym refaktorze.
+
+## Zasada braku zaskoczenia
+
+Skill nie może robić niczego, czego nie zapowiada jego opis. Żadnego kodu, który
+sięga poza zadeklarowany zakres, wysyła dane na zewnątrz albo obchodzi bramki
+projektu. Skill opisany zdaniem musi dać się z tego zdania w całości przewidzieć.
+
+## Co się stanie z twoim skillem u innych klientów
+
+`scripts/install_shared_skills.py` rozkłada `templates/shared/skills/` na osiem
+klientów. Trzy czytają skille natywnie, pięć nie ma takiego formatu:
+
+| Klient | Gdzie ląduje | Jak działa |
+| --- | --- | --- |
+| claude | `.claude/skills/` | natywnie, z zasobami |
+| cursor | `.cursor/skills/` | natywnie, z zasobami |
+| antigravity | `.agents/skills/` | natywnie, z zasobami |
+| codex | `.codex/agents/` | degradacja: komenda `/nazwa` |
+| vscode | `.github/prompts/` | degradacja: komenda `/nazwa` |
+| kiro | `.kiro/agents/` | degradacja: komenda `/nazwa` |
+| kilo | `.kilocode/workflows/` | degradacja: komenda `/nazwa` |
+| opencode | `.opencode/command/` | degradacja: komenda `/nazwa` |
+
+Degradacja ma dwa skutki, z którymi trzeba pisać: skill przestaje odpalać się sam
+(ktoś musi wpisać `/nazwa`) i **gubi wszystko poza `SKILL.md`** — komenda to jeden
+plik. Skill, którego sens leży w `scripts/`, będzie w pięciu na osiem klientów
+wydmuszką. Jeśli tak wychodzi, przemyśl, czy to nie powinien być agent.
+
+Instalator ostrzega o gubionych katalogach na stderr. Traktuj to ostrzeżenie jako
+sygnał projektowy, nie szum.
+
+## Zanim uznasz skill za skończony
+
+- `description` mówi **kiedy** odpalić, konkretnymi zdaniami użytkownika
+- `name` == nazwa katalogu i nie koliduje z agentem
+- `SKILL.md` poniżej ~500 linii, nadmiar w `references/`
+- treść nie powtarza warunków odpalenia
+- skill przeżywa degradację do jednego pliku, albo świadomie z niej rezygnuje
+- `bootstrap-project.sh --clients all` instaluje go u wszystkich ośmiu klientów

--- a/tests/test_bootstrap_clients.sh
+++ b/tests/test_bootstrap_clients.sh
@@ -12,6 +12,8 @@ test -f "$TMP/only-cursor/.cursor/mcp.json"
 test -f "$TMP/only-cursor/AGENTS.md"
 test ! -e "$TMP/only-cursor/.mcp.json"
 test ! -e "$TMP/only-cursor/.kiro"
+# Ten przebieg leci z --skip-agents, więc jest zarazem dowodem, że flaga pomija skille.
+test ! -e "$TMP/only-cursor/.cursor/skills/skill-authoring"
 grep -q '"--clients", "cursor"' "$TMP/only-cursor/.cursor/mcp.json"
 # Guardraile ida ze wspolnego zrodla (templates/shared/guards).
 test -f "$TMP/only-cursor/.cursor/hooks/gate-destructive.sh"
@@ -74,5 +76,34 @@ test ! -e "$TMP/both/.claude/hooks"
 test ! -e "$TMP/both/.claude/settings.json"
 test -f "$TMP/both/.cursor/hooks/gate-destructive.sh"
 echo "OK  prune: claude odznaczony sprzata po sobie"
+
+"$BOOT" "$TMP/skills" --clients all --from "$ROOT" >/dev/null
+# Trzy klienty czytają skille natywnie — katalog skilla z zasobami, nie jeden plik.
+test -f "$TMP/skills/.claude/skills/skill-authoring/SKILL.md"
+test -f "$TMP/skills/.cursor/skills/skill-authoring/SKILL.md"
+test -f "$TMP/skills/.agents/skills/skill-authoring/SKILL.md"
+# Cursorowy skill spoza shared zostaje na miejscu obok kitowych.
+test -f "$TMP/skills/.cursor/skills/compact/SKILL.md"
+# Reszta dostaje ten sam skill jako komendę w swoim formacie.
+test -f "$TMP/skills/.codex/agents/skill-authoring.toml"
+test -f "$TMP/skills/.github/prompts/skill-authoring.prompt.md"
+test -f "$TMP/skills/.kiro/agents/skill-authoring.md"
+test -f "$TMP/skills/.kilocode/workflows/skill-authoring.md"
+test -f "$TMP/skills/.opencode/command/skill-authoring.md"
+# Składany blok YAML (`description: >-`) musi dojechać jako jedno zdanie, nie ">-".
+grep -q 'description = "Jak napisać skill' "$TMP/skills/.codex/agents/skill-authoring.toml"
+echo "OK  shared skills u wszystkich klientów (3 natywnie, 5 przez degradację)"
+
+# .agents/skills i .claude/skills dzielimy ze skillami spoza kita — prune musi
+# kasować po nazwach ze źródła, nie całym katalogiem.
+mkdir -p "$TMP/skills/.agents/skills/obcy-skill"
+echo "nie moj" > "$TMP/skills/.agents/skills/obcy-skill/SKILL.md"
+"$BOOT" "$TMP/skills" --clients claude --from "$ROOT" >/dev/null
+test -f "$TMP/skills/.agents/skills/obcy-skill/SKILL.md"
+test ! -e "$TMP/skills/.agents/skills/skill-authoring"
+test -f "$TMP/skills/.claude/skills/skill-authoring/SKILL.md"
+# Cursor odznaczony w tym samym przebiegu — jego skille znikają razem z resztą.
+test ! -e "$TMP/skills/.cursor/skills"
+echo "OK  prune kasuje kitowe skille, zostawia cudze"
 
 echo "All bootstrap --clients checks passed."

--- a/tests/test_generated_artifacts.py
+++ b/tests/test_generated_artifacts.py
@@ -6,7 +6,8 @@ Dwie luki, które ten moduł zamyka:
 1. Wpis w `manifest.yaml` może wskazywać na nieistniejący plik — dotąd ujawniało
    się to dopiero przy `get_module()` u użytkownika.
 2. To repo dogfooduje własny kit: `.cursor/agents/`, `.claude/agents/` i
-   `.claude/commands/` to kopie `templates/shared/agents/`. Dodanie agenta bez
+   `.claude/commands/` to kopie `templates/shared/agents/`, a `.claude/skills/`
+   to kopia `templates/shared/skills/`. Dodanie agenta albo skilla bez
    regeneracji kopii przechodziło CI niezauważone.
 
 Parytet kopii sprawdzamy **wywołując prawdziwy bootstrap**, a nie powtarzając tu
@@ -31,6 +32,16 @@ KIT_ROOT = find_kit_root(Path(__file__))
 
 # Katalogi, które bootstrap wypełnia z templates/shared/agents/.
 DOGFOOD_DIRS = (".cursor/agents", ".claude/agents", ".claude/commands")
+
+# Skille ze wspólnego źródła sprawdzamy tylko w `.claude/skills/`. Pozostałe dwa
+# natywne katalogi są w .gitignore z dobrego powodu — `.agents/skills/` i
+# `.cursor/skills/*` to miejsca, gdzie lądują też skille instalowane spoza kita
+# (npx skills add), więc kopii kitowych po prostu tam nie śledzimy.
+#
+# Odwrotności — testu "katalog bez źródła w shared to sierota" — tu nie ma i mieć
+# nie może: `.claude/skills/` dzielimy z tymi samymi obcymi skillami (np. wygenerowany
+# `ai-instruction-kit-mcp`), więc nadmiarowy katalog nie jest dowodem na nic.
+DOGFOOD_SKILL_DIR = ".claude/skills"
 
 # Guardraile mają jedno źródło (templates/shared/guards) i trafiają do katalogu
 # hooków każdego klienta, który potrafi je egzekwować. Kopia w tym repo musi być
@@ -157,6 +168,29 @@ class TestDogfoodCopies(unittest.TestCase):
         """Cursor ma tylko `afterFileEdit` — bramka przed zapisem nie ma tam sensu."""
         self.assertFalse((self.generated / ".cursor/hooks/gate-file-writes.mjs").exists())
         self.assertFalse((KIT_ROOT / ".cursor/hooks/gate-file-writes.mjs").exists())
+
+    def _shared_skills(self) -> list[Path]:
+        return sorted(
+            path.parent for path in (KIT_ROOT / "templates" / "shared" / "skills").glob("*/SKILL.md")
+        )
+
+    def test_skill_copies_match_bootstrap_output(self) -> None:
+        """Każdy shared skill ma w repo kopię identyczną z wygenerowaną."""
+        stale: list[str] = []
+        for skill in self._shared_skills():
+            rel = f"{DOGFOOD_SKILL_DIR}/{skill.name}/SKILL.md"
+            in_repo = KIT_ROOT / rel
+            expected = self.generated / rel
+            self.assertTrue(expected.is_file(), msg=f"bootstrap nie zainstalował {rel}")
+            if not in_repo.is_file():
+                stale.append(f"{rel} — brak kopii w repo")
+            elif in_repo.read_text(encoding="utf-8") != expected.read_text(encoding="utf-8"):
+                stale.append(f"{rel} — kopia rozjechała się ze źródłem")
+        self.assertEqual(
+            stale,
+            [],
+            msg="uruchom bootstrap na tym repo albo zregeneruj kopie: " + "; ".join(stale),
+        )
 
     def test_no_orphan_copies(self) -> None:
         """Kopia bez odpowiednika w shared to pozostałość po usuniętym agencie."""

--- a/tests/test_install_shared_skills.py
+++ b/tests/test_install_shared_skills.py
@@ -1,0 +1,154 @@
+"""
+Instalacja skilli ze wspólnego źródła: parser frontmatter i degradacja.
+
+Suita `test_bootstrap_clients.sh` sprawdza, że pliki lądują we właściwych
+katalogach. Tutaj chodzi o to, **co** w nich jest — a konkretnie o dwie rzeczy,
+które łatwo zepsuć po cichu: składany blok YAML w `description` (parser liniowy
+zwróciłby dosłowne ">-", a to jedyne pole odpowiedzialne za odpalanie skilla)
+oraz gubienie zasobów przy degradacji do jednego pliku.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+KIT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(KIT_ROOT / "scripts"))
+
+from install_shared_skills import (  # noqa: E402
+    DEGRADED_CLIENTS,
+    NATIVE_CLIENTS,
+    install_degraded,
+    install_native,
+    iter_skills,
+    parse_frontmatter,
+)
+
+
+def write_skill(root: Path, name: str, frontmatter: str, body: str = "tresc\n") -> Path:
+    skill = root / name
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text(f"---\n{frontmatter}---\n\n{body}", encoding="utf-8")
+    return skill
+
+
+class TestParseFrontmatter(unittest.TestCase):
+    """Frontmatter skilla → pola + treść."""
+
+    def test_plain_scalar(self) -> None:
+        meta, body = parse_frontmatter("---\nname: a\ndescription: jedno zdanie\n---\n\ntresc\n")
+        self.assertEqual(meta, {"name": "a", "description": "jedno zdanie"})
+        self.assertEqual(body, "tresc\n")
+
+    def test_folded_block_becomes_one_line(self) -> None:
+        """`description: >-` z wciętymi liniami to jedno zdanie, nie ">-"."""
+        meta, _ = parse_frontmatter(
+            "---\nname: a\ndescription: >-\n  pierwsza\n  druga\ndisable-model-invocation: true\n---\n\nx\n"
+        )
+        self.assertEqual(meta["description"], "pierwsza druga")
+        self.assertEqual(meta["disable-model-invocation"], "true")
+
+    def test_blank_line_inside_block(self) -> None:
+        """Pusta linia w składanym bloku nie kończy pola."""
+        meta, _ = parse_frontmatter("---\nname: a\ndescription: >-\n  jeden\n\n  dwa\n---\n\nx\n")
+        self.assertEqual(meta["description"], "jeden dwa")
+
+    def test_missing_frontmatter(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_frontmatter("bez frontmatter\n")
+
+    def test_unterminated_frontmatter(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_frontmatter("---\nname: a\n")
+
+
+class TestInstall(unittest.TestCase):
+    """Kopia natywna vs degradacja do komendy."""
+
+    def setUp(self) -> None:
+        import tempfile
+
+        self.tmp = Path(tempfile.mkdtemp(prefix="kit-skills-"))
+        self.src = self.tmp / "src"
+        self.src.mkdir()
+        self.dest = self.tmp / "dest"
+        self.dest.mkdir()
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_iter_skills_only_dirs_with_skill_md(self) -> None:
+        """Katalog bez SKILL.md nie jest skillem."""
+        write_skill(self.src, "prawdziwy", "name: prawdziwy\ndescription: x\n")
+        (self.src / "smiec").mkdir()
+        (self.src / "smiec" / "notatka.md").write_text("x", encoding="utf-8")
+        self.assertEqual([s.name for s in iter_skills(self.src)], ["prawdziwy"])
+
+    def test_native_copies_bundled_resources(self) -> None:
+        """Natywny klient dostaje cały katalog, nie sam SKILL.md."""
+        skill = write_skill(self.src, "z-zasobami", "name: z-zasobami\ndescription: x\n")
+        (skill / "scripts").mkdir()
+        (skill / "scripts" / "run.py").write_text("print(1)\n", encoding="utf-8")
+        install_native(skill, self.dest)
+        self.assertTrue((self.dest / "z-zasobami" / "SKILL.md").is_file())
+        self.assertTrue((self.dest / "z-zasobami" / "scripts" / "run.py").is_file())
+
+    def test_native_reinstall_removes_stale_files(self) -> None:
+        """Druga instalacja nie zostawia pliku usuniętego ze źródła."""
+        skill = write_skill(self.src, "s", "name: s\ndescription: x\n")
+        install_native(skill, self.dest)
+        (self.dest / "s" / "stary.md").write_text("x", encoding="utf-8")
+        install_native(skill, self.dest)
+        self.assertFalse((self.dest / "s" / "stary.md").exists())
+
+    def test_degraded_uses_directory_name_not_frontmatter(self) -> None:
+        """Komendę nazywa katalog — to jedyna nazwa wspólna dla wszystkich klientów."""
+        skill = write_skill(self.src, "katalog", "name: co-innego\ndescription: x\n")
+        install_degraded(skill, self.dest, "opencode")
+        self.assertTrue((self.dest / "katalog.md").is_file())
+        self.assertFalse((self.dest / "co-innego.md").exists())
+
+    def test_degraded_codex_writes_toml(self) -> None:
+        skill = write_skill(self.src, "s", "name: s\ndescription: >-\n  jeden\n  dwa\n")
+        install_degraded(skill, self.dest, "codex")
+        out = (self.dest / "s.toml").read_text(encoding="utf-8")
+        self.assertIn('description = "jeden dwa"', out)
+        self.assertIn("tresc", out)
+
+    def test_degraded_kiro_copies_raw(self) -> None:
+        """kiro czyta surowe pliki agentów — bez renderera, bajt w bajt."""
+        skill = write_skill(self.src, "s", "name: s\ndescription: x\n")
+        install_degraded(skill, self.dest, None)
+        self.assertEqual(
+            (self.dest / "s.md").read_text(encoding="utf-8"),
+            (skill / "SKILL.md").read_text(encoding="utf-8"),
+        )
+
+    def test_degraded_warns_about_dropped_resources(self) -> None:
+        """Gubione `scripts/` musi być głośne — inaczej skill cicho staje się wydmuszką."""
+        skill = write_skill(self.src, "s", "name: s\ndescription: x\n")
+        (skill / "scripts").mkdir()
+        (skill / "scripts" / "run.py").write_text("print(1)\n", encoding="utf-8")
+
+        import contextlib
+        import io
+
+        err = io.StringIO()
+        with contextlib.redirect_stderr(err):
+            install_degraded(skill, self.dest, "kilo")
+        self.assertIn("scripts", err.getvalue())
+
+    def test_every_known_client_has_a_mode(self) -> None:
+        """Każdy klient z `--clients` musi wiedzieć, co zrobić ze skillem."""
+        from guides.clients import KNOWN_CLIENTS
+
+        covered = NATIVE_CLIENTS | set(DEGRADED_CLIENTS)
+        self.assertEqual(sorted(covered), sorted(KNOWN_CLIENTS))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Skille były jedyną warstwą kita bez wspólnego źródła: istniały tylko w `templates/cursor/skills/` i trafiały wyłącznie do Cursora. Ten PR zamyka tę lukę tym samym wzorcem, którym #18 zamknął ją dla guardraili, i dokłada komendę zakładającą issue na nowy skill.

**Wspólne źródło i dystrybucja**

- `templates/shared/skills/<nazwa>/SKILL.md` (+ opcjonalne `references/`, `scripts/`, `assets/`) jako jedyne źródło skilli kita.
- `scripts/install_shared_skills.py` rozkłada je na osiem klientów: `claude`, `cursor` i `antigravity` dostają cały katalog natywnie, pozostała piątka — komendę `/nazwa` w swoim formacie.
- Degradacja kosztuje dwie rzeczy i PR mówi o nich wprost: skill przestaje odpalać się sam i gubi wszystko poza `SKILL.md`. Instalator ostrzega o gubionych katalogach na stderr.
- Własny parser frontmatter, bo skille używają składanych bloków YAML (`description: >-`) — parser liniowy z `render_agent_commands` zwróciłby dosłowne `">-"`, czyli zepsułby jedyne pole odpowiedzialne za odpalanie skilla.
- `prune` kasuje skille po nazwach ze źródła, nigdy całego katalogu: `.claude/skills/` i `.agents/skills/` dzielimy ze skillami instalowanymi spoza kita.

**`/create-skill`**

Symetryczny do `/create-task` (fazy 0–3 tylko czytają, karta jest pełnym podglądem, issue powstaje po `t`), ale z szóstym werdyktem: **„to nie skill, to agent"** → odesłanie do `/create-task`. To najczęstszy błąd przy zakładaniu skilli i jedyny powód, dla którego ta komenda musi istnieć osobno.

Rzemiosło pisania skilla trzyma skill `skill-authoring` — pierwszy mieszkaniec nowego źródła. Dzięki temu agent mieści się w limicie 12000 znaków renderera antigravity (11206), który tnie od końca pliku, czyli akurat sekcję „Zakazy".

## Test plan

- [x] `uv run python -m unittest discover -s tests` — 88 testów, OK (1 skip)
- [x] `uv tool run ty check` — All checks passed
- [x] `tests/test_install_shared_skills.py` — 13 nowych testów: parser frontmatter (skalar, `>-`, pusta linia w bloku, brak/niedomknięty frontmatter), kopia natywna z zasobami, reinstalacja bez pozostałości, nazwa komendy z katalogu, render codex/kiro, ostrzeżenie o gubionych zasobach, pokrycie wszystkich `KNOWN_CLIENTS`
- [x] `tests/test_bootstrap_clients.sh` — instalacja u ośmiu klientów, `prune` zostawiający cudze skille, `--skip-agents` pomijający skille; suita mieści się w limicie 300 s (2m14s)
- [x] `tests/test_generated_artifacts.py` — parytet kopii dogfood dla skilli
- [x] `/review-bugbot` — brak uwag

## Uwagi

- **Base to `master`, nie `dev`.** `origin/dev` stoi 16 commitów wstecz (na PR #17) i nie ma ani guardraili, ani `/create-task`; ostatnie PR-y (#27, #34) mergowały się do `master`.
- Poza zakresem, do osobnego zgłoszenia: `copy_claude_commands` zapisuje pliki bez `newline="\n"`, więc bootstrap na Windowsie brudzi kopie w `.claude/commands/` samym CRLF, wbrew `*.md text eol=lf` z `.gitattributes`.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4ZgV8os4xiAjfS6Dq2nzE