### PR TITLE
fix: read local kit source with uv run --directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ Nie mieszaj: nazwa produktu ≠ preset; porty ≠ tag.
 
 | Flaga              | Wymagana? | Rola                                                                                                                                               | Gdzie / jak zmieniać                                     |
 | ------------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `--from SOURCE`    | tak (uvx) | Źródło kita: `git+https://…` albo absolutna ścieżka lokalna                                                                                        | `.cursor/mcp.json` (i odpowiedniki innych klientów)      |
+| `--from SOURCE`    | przy `uvx` | Źródło zdalne kita: `git+https://…`. Dla lokalnego klonu bootstrap generuje zamiast tego `uv run --directory <ścieżka>` — patrz „Lokalny klon" niżej | `.cursor/mcp.json` (i odpowiedniki innych klientów)      |
 | `--preset NAME`    | tak       | Kategoria z `profiles/NAME.yaml` (`_base`, `shop`, …) — bez aliasów produktowych (używaj `shop`)                                                   | mcp.json; lista: MCP `list_presets` / `profiles/`        |
 | `--language pl|en` | nie       | Język **prozy** (odpowiedzi, docstringi, body issue/PR, commity). **Tytuły** issue/PR/branch zawsze EN. Domyślnie: `language:` w profilu albo `pl` | mcp.json / bootstrap `--language`; env `GUIDES_LANGUAGE` |
 | `--codegen orval\|none\|graphql` | nie | Generator klienta API — patrz sekcja "Codegen" niżej. Domyślnie: `orval` | mcp.json / bootstrap `--codegen`; env `GUIDES_CODEGEN`; tool `get_codegen` |
 | `--clients LIST`   | nie       | Metadane IDE: `all` \| `cursor` \| `claude` \| `codex` \| `vscode` \| `kiro` \| `kilo` \| `antigravity` \| `opencode` (lista; alias `copilot`→`vscode`). **Nie** zmienia treści bundle | mcp.json / bootstrap `--clients` (default `all`); env `GUIDES_CLIENTS`; tool `get_clients` |
+| `--kit-root PATH`  | nie       | Klon kita, z którego serwer czyta `manifest.yaml` / `modules/` / `profiles/`. Bez niej root jest wykrywany automatycznie — a przy `uvx --from <katalog>` wykrywa się kopia z cache `uv` zamiast klonu | mcp.json — bootstrap dodaje sam przy źródle lokalnym; env `GUIDES_KIT_ROOT` |
 | `--workspace PATH` | zalecane  | Root aplikacji — stąd auto `.ai/project.md`                                                                                                        | mcp.json; Cursor/VS: `${workspaceFolder}`                |
 | `--overlay PATH`   | nie       | Extra MD (można wielokrotnie)                                                                                                                      | mcp.json — rzadko; zwykle wystarczy workspace            |
 | `--profile PATH`   | nie       | Lokalny fork YAML zamiast `--preset`                                                                                                               | mcp.json + plik w aplikacji                              |
@@ -391,8 +392,38 @@ Bootstrap to **jednorazowy stempel**, nie sync. Trzy różne zachowania:
 | Co | Przy ponownym `bootstrap-project.sh` |
 | --- | --- |
 | `.claude/agents/`, `.cursor/agents/`, `.claude/commands/`, `mcp.json`/`config.toml` | **Zawsze nadpisane** świeżą kopią z kita — traktuj jak wygenerowany kod, nie edytuj ręcznie |
-| `AGENTS.md`, `.ai/project.md` | Kopiowane **tylko jeśli brak** — bootstrap nigdy więcej ich nie tyka, update ręczny |
-| `modules/*.md` (treść instrukcji) | **W ogóle nie kopiowane** — MCP czyta je live z `--from` przy każdym `get_bundle`/`get_overlay`, więc zawsze aktualne bez re-bootstrapu |
+| `AGENTS.md`, `BUGBOT.md`, `.ai/project.md`, `git-hooks/pre-push` | Kopiowane **tylko jeśli brak** — bootstrap nigdy więcej ich nie tyka, update ręczny. `check_kit_status` wypisuje je w osobnej sekcji „wymagają ręcznego przeniesienia", żeby nie obiecywać nadpisania, którego nie zrobi |
+| `modules/*.md` (treść instrukcji) | **W ogóle nie kopiowane** — MCP czyta je z `--kit-root` przy każdym `get_bundle`/`get_overlay`. Aktualne bez re-bootstrapu **pod warunkiem**, że serwer wie, gdzie jest klon — patrz niżej |
+
+### Lokalny klon: `uv run --directory`, nie `uvx --from`
+
+`uvx --from <katalog>` **nie** czyta kita z tego katalogu w czasie działania. uv buduje koło,
+w którym `manifest.yaml`, `modules/` i `profiles/` lądują jako `guides/_data`
+(`force-include` w `pyproject.toml`), i cache'uje je pod **wersję pakietu**. Wersja nie rośnie
+przy zwykłej edycji modułu ani kodu serwera, więc klient dostaje kopię sprzed builda.
+Do tego `find_kit_root()` woli `_data` od repo, więc `check_kit_status` traci historię gita.
+
+Objaw: poprawiasz `modules/…`, restartujesz klienta, a `get_bundle` wciąż zwraca starą treść.
+Bez komunikatu błędu. To samo dotyczy poprawek w `src/guides/` — serwer nadal biegnie na
+starym kodzie.
+
+Dlatego przy źródle lokalnym bootstrap generuje:
+
+```json
+"command": "uv",
+"args": ["run", "--directory", "/sciezka/do/klona", "guides-mcp", …,
+         "--kit-root", "/sciezka/do/klona", …]
+```
+
+Pakiet ma układ `src/`, więc `uv run` instaluje go jako editable — `_data` w ogóle nie
+powstaje, a kod i moduły czytane są wprost z klonu. `--kit-root` nie jest wtedy konieczny,
+ale zostaje: nazywa klon wprost, zamiast pozwalać serwerowi go wnioskować.
+
+Przy źródle zdalnym (`git+https://…`) nic się nie zmienia — zostaje `uvx --from`, bo klonu
+nie ma, a `_data` z koła jest jedyną i aktualną kopią.
+
+Projekty zbootstrapowane przed tą zmianą mają w `mcp.json` stare `uvx --from` — odpal
+bootstrap ponownie z tymi samymi flagami.
 
 Skąd wiedzieć **kiedy** re-bootstrapować (bez ciągłego czytania plików kita — tanie, jedno porównanie commitów):
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,14 @@ packages = ["src/guides"]
 "manifest.yaml" = "guides/_data/manifest.yaml"
 "modules" = "guides/_data/modules"
 "profiles" = "guides/_data/profiles"
+"scripts/bootstrap-project.sh" = "guides/_data/scripts/bootstrap-project.sh"
 
 [tool.hatch.build.targets.sdist]
 include = [
     "manifest.yaml",
     "modules/**",
     "profiles/**",
+    "scripts/bootstrap-project.sh",
     "src/**",
     "README.md",
 ]

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -296,6 +296,48 @@ text = re.sub(
 if os.environ.get("WORKSPACE_REPL"):
     # Codex placeholder path
     text = text.replace("/ABSOLUTNA/SCIEZKA/DO/PROJEKTU", os.environ["WORKSPACE_REPL"])
+
+# Zrodlo lokalne: `uv run --directory`, nie `uvx --from`.
+#
+# `uvx --from <katalog>` nie czyta kita z tego katalogu w czasie dzialania. uv buduje
+# kolo, w ktorym `manifest.yaml`, `modules/` i `profiles/` laduja jako `guides/_data`
+# (force-include w pyproject.toml), i cache'uje je pod WERSJE pakietu. Wersja nie rosnie
+# przy zwyklej edycji modulu ani kodu serwera, wiec klient dostaje kopie sprzed builda —
+# poprawiasz modul, restartujesz IDE, a `get_bundle` zwraca stara tresc. Bez bledu.
+# Do tego `find_kit_root` woli `_data` od repo, wiec `check_kit_status` traci historie
+# gita i nie ma czego porownac ze stampem.
+#
+# `uv run --directory <katalog>` instaluje pakiet z ukladem `src/` jako editable: `_data`
+# w ogole nie powstaje, kod i moduly czytane sa wprost z klonu. Jedna zmiana naprawia
+# jednoczesnie zamrozone moduly i zamrozony kod serwera.
+#
+# `--kit-root` dokladamy mimo to — nie jest juz konieczny, ale nazywa klon wprost, wiec
+# konfiguracja mowi wprost, skad kit jest czytany, zamiast polegac na wnioskowaniu.
+#
+# Przy zrodle zdalnym (`git+https://…`) nic nie zmieniamy: klonu nie ma, `uvx` jest
+# poprawnym wyborem, a `_data` z kola to jedyna i aktualna kopia.
+from_src = os.environ["FROM_SRC"]
+if Path(from_src).is_dir():
+    # `uvx` występuje w szablonie raz — jako komenda (JSON `"command": "uvx"`,
+    # TOML `command = "uvx"`, opencode jako pierwszy element tablicy `command`).
+    text = text.replace('"uvx"', '"uv"', 1)
+    # `--from X` i `run --directory X` znaczą to samo dla obu poleceń: "weź pakiet stąd".
+    text = re.sub(
+        r'"--from",(\s*)"' + re.escape(from_src) + r'"',
+        lambda m: f'"run", "--directory",{m.group(1)}"{from_src}"',
+        text,
+        count=1,
+    )
+    if "--kit-root" not in text:
+        # Wciecie i styl (JSON vs TOML, spacje po przecinku) biora sie z dopasowanej
+        # linii, wiec wynik wyglada jak reszta pliku, ktorykolwiek klient go dostaje.
+        text = re.sub(
+            r'(^([ \t]*)"--clients",[^\n]*\n)',
+            lambda m: f'{m.group(1)}{m.group(2)}"--kit-root", "{from_src}",\n',
+            text,
+            count=1,
+            flags=re.MULTILINE,
+        )
 dest.write_text(text, encoding="utf-8")
 PY
 }

--- a/src/guides/bootstrap.py
+++ b/src/guides/bootstrap.py
@@ -180,6 +180,12 @@ def run_bootstrap(**kwargs) -> str:
             text=True,
             timeout=_TIMEOUT_SECONDS,
             check=False,
+            # Skrypt (i kazdy proces, ktory sam odpali) nie dostaje stdin serwera MCP.
+            # Ten potok nigdy nie konczy sie EOF-em, wiec cokolwiek probowaloby z niego
+            # czytac — prompt gita, `read` w shellu — wisialoby az do timeoutu zamiast
+            # zwrocic blad. Bootstrap jest nieinteraktywny, wiec pusty stdin to jedyne
+            # poprawne wejscie. Patrz ten sam mechanizm w `guides.kit_status._git`.
+            stdin=subprocess.DEVNULL,
         )
     except FileNotFoundError as exc:
         raise BootstrapError(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -103,6 +103,55 @@ class TestRealRun(_BootstrapTestCase):
             settings = (workspace / ".claude" / "settings.json").read_text(encoding="utf-8")
             self.assertIn("PreToolUse", settings)
 
+    def test_local_source_uses_uv_run_not_uvx(self) -> None:
+        """Lokalny klon: `uv run --directory` czyta kod i moduły z dysku.
+
+        `uvx --from <katalog>` cache'uje koło pod wersję pakietu, więc edycja modułu
+        (albo kodu serwera) nie dociera do klienta, dopóki wersja nie wzrośnie.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+
+            run_bootstrap(
+                target=workspace,
+                kit_root=KIT_ROOT,
+                clients="claude,codex,vscode,opencode",
+                from_src=str(KIT_ROOT),
+            )
+
+            for rel in (
+                ".mcp.json",
+                ".codex/config.toml",
+                ".vscode/mcp.json",
+                "opencode.json",
+            ):
+                with self.subTest(config=rel):
+                    text = (workspace / rel).read_text(encoding="utf-8")
+                    self.assertIn('"uv"', text)
+                    self.assertNotIn('"uvx"', text)
+                    self.assertIn('"run", "--directory"', text)
+                    self.assertNotIn('"--from"', text)
+                    self.assertIn("--kit-root", text)
+
+    def test_remote_source_keeps_uvx(self) -> None:
+        """Przy źródle zdalnym klonu nie ma — `uvx` jest poprawny, a `--kit-root` wskazywałby w pustkę."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+
+            run_bootstrap(
+                target=workspace,
+                kit_root=KIT_ROOT,
+                clients="claude",
+                from_src="git+https://example.com/kit.git",
+            )
+
+            text = (workspace / ".mcp.json").read_text(encoding="utf-8")
+            self.assertIn('"uvx"', text)
+            self.assertIn('"--from"', text)
+            self.assertNotIn("--kit-root", text)
+
     def test_missing_script_is_an_error(self) -> None:
         """Kit bez skryptu bootstrapu — jasny błąd zamiast cichego nic."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Closes #45

> Stack: bazuje na `feat/44-codex-native-skills` (#49). Po jego merge'u zmienię bazę na `master`.

## Co i dlaczego

`uvx --from <katalog>` **nie** czyta kita z tego katalogu w czasie działania. uv buduje koło, w którym `manifest.yaml`, `modules/` i `profiles/` lądują jako `guides/_data`, i cache'uje je pod wersję pakietu — a wersja nie rośnie przy zwykłej edycji modułu ani kodu serwera. Klient dostawał kopię sprzed builda, bez żadnego komunikatu błędu. Do tego `find_kit_root()` woli `_data` od repo, więc `check_kit_status` tracił historię gita.

Przy źródle lokalnym bootstrap generuje teraz `uv run --directory <klon>` plus jawny `--kit-root`. Pakiet ma układ `src/`, więc uv instaluje go jako editable: `_data` w ogóle nie powstaje, kod i moduły czytane są wprost z klonu. Źródło zdalne (`git+https://…`) zostaje przy `uvx` — klonu nie ma, a `_data` z koła jest jedyną aktualną kopią.

## Zmiany

- `bootstrap-project.sh` — podmiana `uvx`/`--from` na `uv run --directory` + `--kit-root`, wyłącznie gdy `--from` wskazuje istniejący katalog.
- `src/guides/bootstrap.py` — `stdin=subprocess.DEVNULL`. Dziedziczony stdin serwera MCP to potok bez EOF-u: cokolwiek próbowałoby z niego czytać, wisiałoby do timeoutu.
- `pyproject.toml` — `bootstrap-project.sh` do force-include i sdist; bez tego MCP-owy `bootstrap_workspace` nie ma czego uruchomić z zainstalowanego pakietu.
- README — sekcja „Lokalny klon: `uv run --directory`, nie `uvx --from`", wiersz `--kit-root`, doprecyzowany `--from`.

## Weryfikacja

Dwa nowe testy w `tests/test_bootstrap.py`: źródło lokalne daje `uv` + `run --directory` + `--kit-root` i **nie** zostawia `uvx`/`--from` w żadnym z czterech plików konfiguracji klientów; źródło zdalne nadal daje `uvx --from` bez `--kit-root`.

## Uwaga migracyjna

Projekty zbootstrapowane wcześniej mają w `mcp.json` stare `uvx --from` — wymagają ponownego bootstrapu z tymi samymi flagami.

🤖 Generated with [Claude Code](https://claude.com/claude-code)