### PR TITLE
feat: sync an instruction-kit section into the consumer .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,29 @@ Zapisuje m.in. MCP per klient (`--preset`, `--language`, `--codegen`, `--clients
 
 **Declarative sync klientów:** domyślnie bootstrap **usuwa** kitowe pliki klientów spoza `--clients` (np. przełączenie z `--clients all` na `--clients claude` sprząta `.cursor/`, `.codex/` itd. wygenerowane przy poprzednim bootstrapie). Flaga `--keep-unselected-clients` wyłącza to sprzątanie — zostają pliki wszystkich klientów kiedykolwiek bootstrapowanych.
 
+### `.gitignore` — co z tego wersjonować
+
+Bootstrap wstawia do `.gitignore` repo aplikacji sekcję między markerami
+`# >>> instruction-kit >>>` i `# <<< instruction-kit <<<`. Przy kolejnych przebiegach
+podmienia ją w całości, więc wpisy się nie duplikują, a reguły spoza markerów zostają
+nietknięte. Źródło: `templates/gitignore-kit.txt`.
+
+Zasada: **konfiguracja AI jest częścią repo.** Hooki bezpieczeństwa, agenci i komendy mają
+działać u każdego, kto sklonuje projekt — nie tylko na maszynie, gdzie odpalono bootstrap.
+Poza gitem zostaje lokalny stan klienta i to, co i tak żyje globalnie:
+
+| Wersjonowane | Ignorowane |
+| --- | --- |
+| `.claude/{agents,commands,hooks,skills}/`, `.claude/settings.json` | `.claude/settings.local.json` (uprawnienia per maszyna) |
+| `.codex/config.toml`, `.codex/skills/` | reszta `.codex/` (stan sesji) |
+| `.vscode/mcp.json`, `.github/prompts/`, `.github/copilot-instructions.md` | — |
+| `.mcp.json`, `AGENTS.md`, `BUGBOT.md`, `.ai/` | `.agents/skills/`, `skills-lock.json` (skille z `npx skills add` — instalowane globalnie w `~/.agents/skills/`, kopia w repo zaraz rozjedzie się z globalną) |
+
+Typowy `.gitignore` ma `.claude/` wpisane hurtem — wtedy hooki i komendy nigdy nie trafiają
+do repo, a bootstrap trzeba powtarzać na każdej maszynie. Reguły kita są w formie „ignoruj
+katalog, odwróć dla plików kita", bo git nie wchodzi do zignorowanego katalogu i sam wyjątek
+na plik by nie wystarczył.
+
 ### Bootstrap bez klona kita — narzędzie MCP `bootstrap_workspace`
 
 Jeśli projekt ma już podłączony serwer MCP `project-guides`, kita nie trzeba klonować ani ręcznie odpalać skryptu — serwer ma szablony pod ręką i uruchamia ten sam `bootstrap-project.sh` u siebie. Poproś agenta o wywołanie narzędzia:

--- a/scripts/bootstrap-project.sh
+++ b/scripts/bootstrap-project.sh
@@ -342,6 +342,83 @@ dest.write_text(text, encoding="utf-8")
 PY
 }
 
+# Wstaw (albo odśwież) sekcję kita w .gitignore repo aplikacji.
+#
+# Bootstrap instaluje kilkadziesiąt plików konfiguracji AI, ale to repo konsumenta
+# decyduje, co trafia do gita — a typowy .gitignore ma `.claude/` wpisane hurtem, więc
+# hooki bezpieczeństwa i komendy zostają tylko na maszynie, gdzie odpalono bootstrap.
+#
+# Sekcja jest ograniczona markerami i podmieniana w całości, więc kolejne przebiegi
+# nie duplikują wpisów, a reguły spoza markerów zostają nietknięte. Marker końcowy
+# jest wymagany: bez niego nie wiemy, gdzie kończy się nasza sekcja, więc wtedy
+# dopisujemy nową na końcu, zamiast zgadywać i skasować cudze reguły.
+GITIGNORE_BEGIN="# >>> instruction-kit >>>"
+GITIGNORE_END="# <<< instruction-kit <<<"
+
+sync_gitignore_section() {
+  local target_file="$TARGET/.gitignore"
+  local template="$KIT_ROOT/templates/gitignore-kit.txt"
+  [[ -f "$template" ]] || return 0
+
+  BEGIN_MARK="$GITIGNORE_BEGIN" END_MARK="$GITIGNORE_END" \
+  SHARED_SKILLS="$SHARED_SKILLS" CURSOR_SKILLS="$KIT_ROOT/templates/cursor/skills" \
+  TEMPLATE="$template" DEST="$target_file" "$PYTHON_BIN" - <<'PY'
+import os
+from pathlib import Path
+
+begin = os.environ["BEGIN_MARK"]
+end = os.environ["END_MARK"]
+dest = Path(os.environ["DEST"])
+body = Path(os.environ["TEMPLATE"]).read_text(encoding="utf-8").strip("\n")
+
+
+def skill_allow(dest_prefix: str, *source_dirs: str) -> str:
+    """Wyjątki `!` dla skilli kita — po nazwie, żeby nie wciągnąć cudzych.
+
+    Katalog skilli u konsumenta miesza dwa źródła: te z kita (pliki) i dowiązania do
+    `.agents/skills/` z `npx skills add` (ignorowane). Wersjonujemy tylko pierwsze.
+    """
+    names: list[str] = []
+    for source in source_dirs:
+        root = Path(source)
+        if not root.is_dir():
+            continue
+        names.extend(sorted(p.name for p in root.iterdir() if p.is_dir()))
+    lines: list[str] = []
+    for name in sorted(set(names)):
+        lines.append(f"!{dest_prefix}/{name}/")
+        lines.append(f"!{dest_prefix}/{name}/**")
+    return "\n".join(lines) if lines else f"# (kit nie dostarcza skilli dla {dest_prefix})"
+
+
+shared = os.environ["SHARED_SKILLS"]
+body = body.replace("@KIT_SKILLS_CLAUDE@", skill_allow(".claude/skills", shared))
+body = body.replace(
+    "@KIT_SKILLS_CURSOR@",
+    skill_allow(".cursor/skills", shared, os.environ["CURSOR_SKILLS"]),
+)
+
+section = f"{begin}\n{body}\n{end}\n"
+
+existing = dest.read_text(encoding="utf-8") if dest.is_file() else ""
+
+if begin in existing and end in existing:
+    head, _, rest = existing.partition(begin)
+    _, _, tail = rest.partition(end)
+    updated = f"{head}{section}{tail.lstrip(chr(10))}"
+    action = "zaktualizowano"
+else:
+    prefix = existing if not existing or existing.endswith("\n") else existing + "\n"
+    separator = "\n" if prefix.strip() else ""
+    updated = f"{prefix}{separator}{section}"
+    action = "dodano"
+
+if updated != existing:
+    dest.write_text(updated, encoding="utf-8")
+    print(f"  + .gitignore ({action} sekcję instruction-kit)")
+PY
+}
+
 copy_shared_agents() {
   local dest_dir="$1"
   if [[ "$SKIP_AGENTS" -ne 0 ]]; then
@@ -670,6 +747,8 @@ if [[ "$WITH_OVERLAY" -eq 1 ]]; then
     echo "  + .ai/project.md"
   fi
 fi
+
+sync_gitignore_section
 
 if [[ "$WITH_PLUGINS" -eq 1 ]]; then
   install_plugins

--- a/templates/gitignore-kit.txt
+++ b/templates/gitignore-kit.txt
@@ -1,0 +1,62 @@
+# Pliki instalowane przez instruction-kit (bootstrap-project.sh).
+#
+# Zasada: konfiguracja AI jest częścią repo — hooki bezpieczeństwa, agenci i komendy
+# mają działać u każdego, kto klonuje projekt, nie tylko na maszynie, gdzie odpalono
+# bootstrap. Lokalny stan klienta (sesje, cache, ustawienia prywatne) zostaje poza gitem.
+#
+# Reguły są w formie "ignoruj katalog, odwróć dla plików kita", bo klienci AI trzymają
+# w tych samych katalogach dane sesji. Git nie wejdzie do zignorowanego katalogu, więc
+# wyjątek na sam plik nie wystarczy — musi być też wyjątek na katalog po drodze.
+
+# --- Claude Code -------------------------------------------------------------
+.claude/*
+!.claude/agents/
+!.claude/agents/**
+!.claude/commands/
+!.claude/commands/**
+!.claude/hooks/
+!.claude/hooks/**
+!.claude/skills/
+# Wersjonujemy tylko skille kita, wyliczone z nazwy. Reszta zawartosci tego katalogu
+# to zwykle dowiazania do `.agents/skills/` (npx skills add), ktory jest ignorowany —
+# w repo bylyby to linki donikad, na dodatek ze sciezka absolutna maszyny, na ktorej
+# odpalono instalator.
+.claude/skills/*
+@KIT_SKILLS_CLAUDE@
+!.claude/settings.json
+# Prywatne nadpisania: uprawnienia, włączone serwery MCP. Per maszyna, nie per repo.
+.claude/settings.local.json
+
+# --- Codex CLI ---------------------------------------------------------------
+.codex/*
+!.codex/config.toml
+!.codex/skills/
+!.codex/skills/**
+
+# --- GitHub Copilot (VS Code) ------------------------------------------------
+# .vscode bywa ignorowane globalnie — te trzy wpisy to konfiguracja kita, nie stan IDE.
+!.vscode/mcp.json
+!.github/copilot-instructions.md
+!.github/prompts/
+!.github/prompts/**
+
+# --- Cursor ------------------------------------------------------------------
+.cursor/*
+!.cursor/mcp.json
+!.cursor/hooks.json
+!.cursor/BUGBOT.md
+!.cursor/agents/
+!.cursor/agents/**
+!.cursor/hooks/
+!.cursor/hooks/**
+!.cursor/rules/
+!.cursor/rules/**
+!.cursor/skills/
+.cursor/skills/*
+@KIT_SKILLS_CURSOR@
+
+# --- Skille spoza kita (npx skills add …) ------------------------------------
+# Instalowane globalnie w ~/.agents/skills/ i linkowane do projektu. Kopia w repo
+# to duplikat, który zaraz rozjedzie się z globalną wersją — trzymaj je globalnie.
+.agents/skills/
+skills-lock.json

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -20,6 +20,7 @@ from guides import server
 from guides.bootstrap import BootstrapError, find_bash, plan_bootstrap, run_bootstrap
 
 KIT_ROOT = Path(__file__).resolve().parents[1]
+KIT_SKILLS_TEMPLATE = (KIT_ROOT / "templates" / "gitignore-kit.txt").read_text(encoding="utf-8")
 
 
 def _snapshot(root: Path) -> dict[str, bytes]:
@@ -151,6 +152,50 @@ class TestRealRun(_BootstrapTestCase):
             self.assertIn('"uvx"', text)
             self.assertIn('"--from"', text)
             self.assertNotIn("--kit-root", text)
+
+    def test_gitignore_section_is_added_and_idempotent(self) -> None:
+        """Sekcja kita wchodzi raz, nie duplikuje się i nie depcze reguł projektu."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+            gitignore = workspace / ".gitignore"
+            gitignore.write_text("node_modules/\n.env\n", encoding="utf-8")
+
+            run_bootstrap(target=workspace, kit_root=KIT_ROOT, clients="claude")
+            first = gitignore.read_text(encoding="utf-8")
+            run_bootstrap(target=workspace, kit_root=KIT_ROOT, clients="claude")
+            second = gitignore.read_text(encoding="utf-8")
+
+            self.assertEqual(first, second, "druga instalacja zmieniła .gitignore")
+            self.assertEqual(second.count("# >>> instruction-kit >>>"), 1)
+            self.assertIn("node_modules/", second)
+            self.assertIn(".claude/settings.local.json", second)
+            self.assertIn(".agents/skills/", second)
+
+    def test_gitignore_allows_kit_skills_by_name_only(self) -> None:
+        """Katalog skilli miesza pliki kita z dowiązaniami do ignorowanego `.agents/skills/`.
+
+        Whitelist musi wymieniać skille kita po nazwie — `!.claude/skills/**` wciągnąłby
+        też te dowiązania, a w repo byłyby linkami donikąd (ze ścieżką absolutną maszyny).
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp) / "app"
+            workspace.mkdir()
+
+            run_bootstrap(target=workspace, kit_root=KIT_ROOT, clients="claude")
+            gitignore = (workspace / ".gitignore").read_text(encoding="utf-8")
+
+            self.assertIn(".claude/skills/*", gitignore)
+            self.assertNotIn("!.claude/skills/**", gitignore)
+            self.assertIn("@KIT_SKILLS_CLAUDE@", KIT_SKILLS_TEMPLATE)
+            self.assertNotIn("@KIT_SKILLS_CLAUDE@", gitignore)
+
+            for name in sorted(
+                p.name for p in (KIT_ROOT / "templates" / "shared" / "skills").iterdir()
+                if p.is_dir()
+            ):
+                with self.subTest(skill=name):
+                    self.assertIn(f"!.claude/skills/{name}/", gitignore)
 
     def test_missing_script_is_an_error(self) -> None:
         """Kit bez skryptu bootstrapu — jasny błąd zamiast cichego nic."""


### PR DESCRIPTION
Closes #46

> Stack: bazuje na `fix/45-local-kit-source-uv-run` (#50). Po merge'u poprzedników zmienię bazę na `master`.

## Co i dlaczego

Bootstrap instaluje kilkadziesiąt plików konfiguracji AI, ale o tym, co trafia do gita, decyduje `.gitignore` repo konsumenta — a typowy ma `.claude/` wpisane hurtem. Hooki bezpieczeństwa, agenci i komendy zostawały wtedy na jednej maszynie, zamiast działać u każdego, kto sklonuje projekt.

Zasada, którą to utrwala: **konfiguracja AI jest częścią repo.** Poza gitem zostaje lokalny stan klienta (`settings.local.json`, sesje) i to, co żyje globalnie (`.agents/skills/`, `skills-lock.json`).

## Zmiany

- `templates/gitignore-kit.txt` — nowy. Reguły w formie „ignoruj katalog, odwróć dla plików kita": git nie wchodzi do zignorowanego katalogu, więc sam wyjątek na plik nie wystarczy.
- `sync_gitignore_section()` w `bootstrap-project.sh` — sekcja ograniczona markerami `# >>> instruction-kit >>>` / `# <<< instruction-kit <<<`, podmieniana w całości. Bez markera końcowego dopisujemy nową sekcję na końcu, zamiast zgadywać zakres i skasować cudze reguły.
- Placeholdery `@KIT_SKILLS_CLAUDE@` / `@KIT_SKILLS_CURSOR@` rozwijane do wyjątków **po nazwach** skilli kita. Katalog skilli u konsumenta miesza pliki kita z dowiązaniami do ignorowanego `.agents/skills/` — `!.claude/skills/**` wciągnąłby też je, a w repo byłyby linkami donikąd ze ścieżką absolutną maszyny instalacyjnej.
- README — sekcja „`.gitignore` — co z tego wersjonować" z tabelą wersjonowane / ignorowane.

## Weryfikacja

Dwa nowe testy: sekcja wchodzi dokładnie raz, druga instalacja nie zmienia pliku, reguły projektu (`node_modules/`) zostają; whitelist skilli jest wyliczana po nazwie — `.claude/skills/*` plus `!.claude/skills/<nazwa>/`, bez `!.claude/skills/**`, a placeholder znika z wyniku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)