### PR TITLE
fix: report the real git failure and split overwritten from manual files

### DIFF
--- a/src/guides/kit_status.py
+++ b/src/guides/kit_status.py
@@ -8,19 +8,36 @@ from pathlib import Path
 
 STAMP_REL_PATH = ".ai/.kit-bootstrap.json"
 
-# Ścieżki które bootstrap-project.sh faktycznie kopiuje/renderuje do konsumenta —
-# tylko te obchodzą "czy trzeba re-bootstrapować" (treść modules/*.md kit czyta live,
-# nie kopiuje, więc nie wchodzi do tej listy).
-_TRACKED_GLOBS: tuple[str, ...] = (
+# Ścieżki które bootstrap-project.sh **nadpisuje** przy każdym przebiegu. Zmiana
+# któregokolwiek z tych plików w kicie znaczy: re-bootstrap wciągnie ją sam.
+# (Treść modules/*.md nie wchodzi tu wcale — kit czyta ją live, nie kopiuje.)
+_OVERWRITTEN_GLOBS: tuple[str, ...] = (
     "templates/shared/agents/*.md",
+    "templates/shared/guards/*",
+    "templates/shared/skills/*/*.md",
     "templates/*/mcp.json",
     "templates/*/mcp_config.json",
     "templates/codex/config.toml",
     "templates/opencode/opencode.json",
-    "templates/AGENTS.md",
-    "templates/project.md",
+    "templates/vscode/github/copilot-instructions.md",
+    "templates/cursor/rules/*.mdc",
     "scripts/bootstrap-project.sh",
     "scripts/render_agent_commands.py",
+    "scripts/install_shared_skills.py",
+    "scripts/claude_settings.py",
+)
+
+# Ścieżki kopiowane **tylko gdy plik u konsumenta jeszcze nie istnieje** (`if [[ ! -f …]]`
+# w bootstrap-project.sh). Re-bootstrap ich NIE ruszy, żeby nie zdeptać lokalnych
+# treści projektu — więc gdy zmienią się w kicie, trzeba je przenieść ręcznie.
+# Rozdzielenie od listy wyżej jest po to, żeby status nie obiecywał nadpisania,
+# którego bootstrap nie zrobi.
+_MANUAL_GLOBS: tuple[str, ...] = (
+    "templates/AGENTS.md",
+    "templates/project.md",
+    "templates/project.profile.yaml",
+    "templates/cursor/BUGBOT.md",
+    "templates/git-hooks/pre-push",
 )
 
 
@@ -35,19 +52,62 @@ def _read_stamp(workspace_root: Path) -> dict | None:
     return data if isinstance(data, dict) else None
 
 
+# Ile czekamy na jedno wywolanie gita. Repo na dysku sieciowym albo zimny cache
+# systemu plikow potrafia przekroczyc sekunde, wiec prog jest z zapasem — to i tak
+# tylko zabezpieczenie przed zawieszeniem, nie budzet wydajnosciowy.
+_GIT_TIMEOUT_SECONDS = 20
+
+# Ostatni powod, dla ktorego `_git` zwrocil None. Bez tego kazda awaria — brak gita
+# w PATH, timeout, katalog bez `.git`, odmowa "dubious ownership" — konczyla sie tym
+# samym komunikatem "kit_root nie jest (juz) repo git", ktory dla trzech z tych
+# czterech przyczyn jest po prostu nieprawdziwy i wysyla czytelnika w zla strone.
+_last_git_error: str | None = None
+
+
 def _git(kit_root: Path, *args: str) -> str | None:
+    """
+    Uruchom gita w ``kit_root`` i zwroc stdout albo ``None`` przy dowolnej awarii.
+
+    Powod awarii laduje w ``_last_git_error`` — wywolujacy raportuje go uzytkownikowi,
+    zamiast zgadywac, ze kazde ``None`` znaczy "to nie jest repo".
+
+    Args:
+        kit_root: Katalog repo kita (``git -C``).
+        *args: Argumenty gita, np. ``("rev-parse", "HEAD")``.
+
+    Returns:
+        str | None: Przyciety stdout, albo ``None`` gdy git nie wystartowal,
+            przekroczyl limit czasu albo zwrocil niezerowy kod.
+    """
+    global _last_git_error
     try:
         result = subprocess.run(
             ["git", "-C", str(kit_root), *args],
             capture_output=True,
             text=True,
-            timeout=5,
+            timeout=_GIT_TIMEOUT_SECONDS,
             check=False,
+            # Bez tego dziecko dziedziczy stdin serwera MCP — potok od klienta, ktory
+            # nigdy nie dostaje EOF. Git czeka wtedy na wejscie, ktore nie nadchodzi,
+            # i kazde wywolanie konczy sie timeoutem zamiast odpowiedzia. Widac to
+            # tylko pod serwerem (stdio transport); z terminala ten sam kod dziala.
+            stdin=subprocess.DEVNULL,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except FileNotFoundError:
+        _last_git_error = "nie znaleziono `git` w PATH procesu serwera MCP"
+        return None
+    except OSError as exc:
+        _last_git_error = f"nie udalo sie uruchomic gita: {exc}"
+        return None
+    except subprocess.TimeoutExpired:
+        _last_git_error = f"git nie odpowiedzial w {_GIT_TIMEOUT_SECONDS}s"
         return None
     if result.returncode != 0:
+        stderr = (result.stderr or "").strip().splitlines()
+        detail = stderr[0][:200] if stderr else f"kod wyjscia {result.returncode}"
+        _last_git_error = f"git zwrocil blad: {detail}"
         return None
+    _last_git_error = None
     return result.stdout.strip()
 
 
@@ -92,8 +152,12 @@ def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
     current_commit = _git(kit_root, "rev-parse", "HEAD")
     if current_commit is None:
         return (
-            "# Kit status: kit_root nie jest (już) repo git\n\n"
-            f"Ścieżka: `{kit_root}`. Nie można porównać — sprawdź ręcznie."
+            "# Kit status: nie udało się odczytać commitu kita\n\n"
+            f"- Ścieżka kita: `{kit_root}`\n"
+            f"- Powód: {_last_git_error or 'nieznany'}\n\n"
+            "Gdy ścieżka wskazuje katalog w cache `uv` (`…/uv/cache/…/guides/_data`), "
+            "serwer czyta **kopię** kita z koła, a nie Twój klon — dodaj "
+            "`--kit-root /sciezka/do/klona` do argumentów `guides-mcp`."
         )
 
     if current_commit == stamp_commit:
@@ -105,13 +169,19 @@ def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
         )
 
     count = _git(kit_root, "rev-list", "--count", f"{stamp_commit}..{current_commit}")
-    changed_files: list[str] = []
-    for pattern in _TRACKED_GLOBS:
-        out = _git(
-            kit_root, "diff", "--name-only", f"{stamp_commit}..{current_commit}", "--", pattern
-        )
-        if out:
-            changed_files.extend(line for line in out.splitlines() if line)
+
+    def changed(globs: tuple[str, ...]) -> list[str]:
+        found: list[str] = []
+        for pattern in globs:
+            out = _git(
+                kit_root, "diff", "--name-only", f"{stamp_commit}..{current_commit}", "--", pattern
+            )
+            if out:
+                found.extend(line for line in out.splitlines() if line)
+        return sorted(set(found))
+
+    overwritten = changed(_OVERWRITTEN_GLOBS)
+    manual = changed(_MANUAL_GLOBS)
 
     lines = [
         "# Kit status: ZMIENIŁ SIĘ od ostatniego bootstrapu",
@@ -121,23 +191,36 @@ def check_kit_updates(kit_root: Path, workspace_root: Path) -> str:
         + (f" ({count} commitów później)" if count else ""),
         "",
     ]
-    if changed_files:
-        lines.append("## Pliki które re-bootstrap by nadpisał:")
+    if overwritten:
+        lines.append("## Re-bootstrap wciągnie sam (pliki nadpisywane):")
         lines.append("")
-        lines.extend(f"- `{f}`" for f in sorted(set(changed_files)))
+        lines.extend(f"- `{f}`" for f in overwritten)
         lines.append("")
         lines.append(
             "Zaktualizuj narzędziem MCP `bootstrap_workspace` (dry run najpierw) albo "
             "ponownym `bootstrap-project.sh` z tymi samymi flagami co poprzednio. "
-            "**Nadpisze** `.claude/agents/`, `.cursor/agents/`, "
-            "`.claude/commands/`, `mcp.json` — jeśli je ręcznie edytowałeś, zrób "
-            "`git diff` najpierw."
+            "**Nadpisze** `.claude/agents/`, `.claude/commands/`, `.claude/hooks/`, "
+            "`.codex/skills/`, `.github/prompts/`, `mcp.json` — jeśli je ręcznie "
+            "edytowałeś, zrób `git diff` najpierw."
         )
-    else:
+    if manual:
+        if overwritten:
+            lines.append("")
+        lines.append("## Wymagają ręcznego przeniesienia (bootstrap ich NIE nadpisze):")
+        lines.append("")
+        lines.extend(f"- `{f}`" for f in manual)
+        lines.append("")
+        lines.append(
+            "Te pliki bootstrap kopiuje wyłącznie gdy u konsumenta jeszcze ich nie ma, "
+            "żeby nie zdeptać lokalnej treści projektu. Skoro szablon w kicie się "
+            "zmienił, a Twoja kopia już istnieje — porównaj ją z `templates/` i przenieś "
+            "to, czego potrzebujesz."
+        )
+    if not overwritten and not manual:
         lines.append(
             "Kit ma nowe commity, ale żaden nie dotyka plików które bootstrap kopiuje "
-            "do tego repo (agents/commands/mcp.json) — re-bootstrap niepotrzebny. "
-            "Moduły instrukcji (`modules/*.md`) i tak są czytane live, bez kopii."
+            "do tego repo — re-bootstrap niepotrzebny. Moduły instrukcji "
+            "(`modules/*.md`) i tak są czytane live, bez kopii."
         )
 
     return "\n".join(lines)

--- a/tests/test_kit_status.py
+++ b/tests/test_kit_status.py
@@ -28,6 +28,7 @@ def _init_kit_repo(kit_root: Path) -> None:
     agents_dir = kit_root / "templates" / "shared" / "agents"
     agents_dir.mkdir(parents=True)
     (agents_dir / "git-start.md").write_text("v1\n", encoding="utf-8")
+    (kit_root / "templates" / "AGENTS.md").write_text("agents v1\n", encoding="utf-8")
     (kit_root / "unrelated.md").write_text("noise\n", encoding="utf-8")
     _git(kit_root, "add", "-A")
     _git(kit_root, "commit", "-q", "-m", "initial")
@@ -122,6 +123,66 @@ class TestKitStatus(unittest.TestCase):
             self.assertIn("ZMIENIŁ SIĘ", out)
             self.assertIn("re-bootstrap niepotrzebny", out)
             self.assertNotIn("unrelated.md", out)
+
+    def test_manual_file_is_not_promised_as_overwritten(self) -> None:
+        """AGENTS.md bootstrap kopiuje tylko gdy brak — status nie może obiecać nadpisania."""
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            (kit_root / "templates" / "AGENTS.md").write_text("agents v2\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "update AGENTS template")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("templates/AGENTS.md", out)
+            self.assertIn("NIE nadpisze", out)
+            self.assertNotIn("Re-bootstrap wciągnie sam", out)
+
+    def test_overwritten_and_manual_reported_separately(self) -> None:
+        """Zmiana w obu kategoriach naraz — każda ląduje pod swoim nagłówkiem."""
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            (kit_root / "templates" / "shared" / "agents" / "git-start.md").write_text(
+                "v2\n", encoding="utf-8"
+            )
+            (kit_root / "templates" / "AGENTS.md").write_text("agents v2\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "update both")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("Re-bootstrap wciągnie sam", out)
+            self.assertIn("NIE nadpisze", out)
+            overwritten_at = out.index("Re-bootstrap wciągnie sam")
+            manual_at = out.index("NIE nadpisze")
+            self.assertLess(overwritten_at, manual_at)
+            # git-start jest nadpisywany, AGENTS.md nie — każdy pod swoją sekcją.
+            self.assertLess(out.index("git-start.md"), manual_at)
+            self.assertGreater(out.index("templates/AGENTS.md"), manual_at)
+
+    def test_guard_change_is_reported(self) -> None:
+        """Hooki bezpieczeństwa też są kopiowane — ich zmiana musi być widoczna."""
+        with tempfile.TemporaryDirectory() as tmp:
+            kit_root = Path(tmp) / "kit"
+            workspace = Path(tmp) / "workspace"
+            _init_kit_repo(kit_root)
+            _write_stamp(workspace, kit_commit=_head(kit_root))
+
+            guards = kit_root / "templates" / "shared" / "guards"
+            guards.mkdir(parents=True)
+            (guards / "gate-destructive.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+            _git(kit_root, "add", "-A")
+            _git(kit_root, "commit", "-q", "-m", "add guard")
+
+            out = check_kit_updates(kit_root, workspace)
+            self.assertIn("templates/shared/guards/gate-destructive.sh", out)
+            self.assertIn("Re-bootstrap wciągnie sam", out)
 
     def test_net_zero_change_shows_no_tracked_diff(self) -> None:
         """Commit + revert netto się znoszą — diff --name-only nic nie pokaże."""


### PR DESCRIPTION
Closes #47

> Stack: bazuje na `feat/46-gitignore-kit-section` (#51). Po merge'u poprzedników zmienię bazę na `master`.

## Co i dlaczego

Dwa niezależne błędy w `check_kit_status`.

**1. Każda awaria gita wyglądała tak samo.** `_git()` zwracało `None` przy braku gita w PATH, timeoucie, odmowie „dubious ownership" i przy katalogu bez `.git` — a raport zawsze mówił „kit_root nie jest (już) repo git". Dla trzech z czterech przyczyn nieprawda. Do tego podproces dziedziczył stdin serwera MCP (potok bez EOF-u), więc pod stdio-transportem **każde** wywołanie kończyło się timeoutem; z terminala ten sam kod działał.

**2. Status obiecywał nadpisanie, którego bootstrap nie robi.** `_TRACKED_GLOBS` mieszało pliki nadpisywane przy każdym przebiegu z tymi kopiowanymi tylko gdy brak (`AGENTS.md`, `project.md`, `BUGBOT.md`, `git-hooks/pre-push`). Użytkownik odpalał re-bootstrap i dostawał ciszę zamiast aktualizacji. Lista pomijała też pliki, które bootstrap faktycznie nadpisuje: guardy, skille, `copilot-instructions.md`, reguły Cursora, skrypty instalacyjne.

## Zmiany

- `_git()` — `stdin=DEVNULL`, timeout 20 s (repo na dysku sieciowym potrafi przekroczyć sekundę), rozdzielone gałęzie `FileNotFoundError` / `OSError` / `TimeoutExpired` / niezerowy kod, powód w `_last_git_error`.
- Komunikat błędu podaje ścieżkę i powód, plus wskazówkę na wypadek, gdy ścieżka wskazuje cache `uv` (`…/guides/_data`) zamiast klonu.
- `_OVERWRITTEN_GLOBS` i `_MANUAL_GLOBS` zamiast jednej listy; raport ma dwie sekcje: „Re-bootstrap wciągnie sam" i „Wymagają ręcznego przeniesienia (bootstrap ich NIE nadpisze)".

## Weryfikacja

Trzy nowe testy: plik ręczny (`templates/AGENTS.md`) nie jest obiecany jako nadpisywany; zmiana w obu kategoriach naraz ląduje pod właściwymi nagłówkami, w właściwej kolejności; zmiana guarda jest widoczna w sekcji nadpisywanych.

🤖 Generated with [Claude Code](https://claude.com/claude-code)